### PR TITLE
Clydetools add-build now skips unsupported file formats

### DIFF
--- a/.changes/unreleased/Fixed-20220718-232537.yaml
+++ b/.changes/unreleased/Fixed-20220718-232537.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: clydetools add-build now skips unsupported file formats like .deb, .rpm or .msi.
+time: 2022-07-18T23:25:37.740637723+02:00


### PR DESCRIPTION
For example .deb, .rpm or .msi.
