### PR TITLE
Fix segfault when downloading packages on recent Ubuntu versions

### DIFF
--- a/ci/build-app
+++ b/ci/build-app
@@ -1,12 +1,31 @@
 #!/bin/bash
 set -euo pipefail
 
+CROSS_VERSION=0.2.4
+
 . $(dirname $0)/functions.sh
 
 init_system_vars
 
+setup_cross() {
+    CARGO_CMD=$(command -v cross || true)
+    if [ -z "$CARGO_CMD" ] ; then
+        echo "Installing cross $CROSS_VERSION"
+        cargo install cross --version $CROSS_VERSION
+    fi
+    CARGO_CMD=$(command -v cross || true)
+    if [ -z "$CARGO_CMD" ] ; then
+        die "Failed to install cross"
+    fi
+    echo "Using cross: CARGO_CMD=$CARGO_CMD"
+}
+
 if [ "$OS_NAME" = "linux" ]; then
     export RUSTFLAGS='-C target-feature=+crt-static'
+    rustup target add $CARGO_BUILD_TARGET
+    setup_cross
+else
+    CARGO_CMD=cargo
 fi
 
-cargo build --verbose --release
+$CARGO_CMD build --verbose --release

--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -16,7 +16,7 @@ init_system_vars() {
     case "$out" in
     Linux)
         OS_NAME=linux
-        export CARGO_BUILD_TARGET="$ARCH-unknown-linux-gnu"
+        export CARGO_BUILD_TARGET="$ARCH-unknown-linux-musl"
         ;;
     Darwin)
         OS_NAME=macos


### PR DESCRIPTION
Build with musl, because glibc versions must match when resolving names.
