### PR TITLE
Fix `./clyde install clyde`

### DIFF
--- a/.changes/unreleased/Fixed-20220728-194025.yaml
+++ b/.changes/unreleased/Fixed-20220728-194025.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fixed bug which caused `./clyde install clyde` to fail (#58).
+time: 2022-07-28T19:40:25.630391095+02:00


### PR DESCRIPTION
Do not consider `install` arguments as package files unless they end with
".yaml". This avoids confusions.

Fixes #5.
