### PR TITLE
post release updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       # Only build on pushes to the main branch, otherwise branches pushed for PR
       # are built twice
       - main
+    tags:
   workflow_dispatch:
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "clyde"
-version = "0.3.0"
+version = "0.3.1-alpha.1"
 dependencies = [
  "anyhow",
  "archiver-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clyde"
-version = "0.3.0"
+version = "0.3.1-alpha.1"
 authors = ["Aurélien Gâteau <mail@agateau.com>"]
 edition = "2021"
 description = "A cross-platform package manager for prebuilt applications"

--- a/tasks.py
+++ b/tasks.py
@@ -126,6 +126,10 @@ def tag(c):
     version = get_version()
     erun("git checkout main")
     erun("git pull")
+    changes_file = Path(".changes") / f"{version}.md"
+    if not changes_file.exists():
+        print(f"{changes_file} does not exist, check previous PR has been merged")
+        sys.exit(1)
     if not is_ok("Create tag?"):
         sys.exit(1)
 

--- a/tasks.py
+++ b/tasks.py
@@ -52,24 +52,10 @@ def is_ok(msg: str) -> bool:
 @task
 def create_pr(c):
     """Create a pull-request and mark it as auto-mergeable"""
-    def extract_pr_id(text):
-        match = re.search(r"/pull/(\d+)", text)
-        if not match:
-            print(f"Can't find pull request ID from:\n'''\n{text}\n'''")
-            sys.exit(1)
-        return match.group(1)
-
     result = cerun(c, "gh pr create --fill", warn=True)
-    if result:
-        pr_id = extract_pr_id(result.stdout)
-    elif "a pull request for branch" in result.stderr:
-        # PR already opened, PR ID is in stderr
-        pr_id = extract_pr_id(result.stderr)
-    else:
+    if not result:
         sys.exit(1)
-
-    print(f"Pull request ID: {pr_id}")
-    cerun(c, f"gh pr merge --auto -dm {pr_id}")
+    cerun(c, f"gh pr merge --auto -dm")
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -115,6 +115,9 @@ def prepare_release3(c):
 
     erun("cargo publish --dry-run --allow-dirty")
     erun("cargo package --list --allow-dirty")
+
+    # `publish --dry-run` updates Cargo.lock. Commit the changes.
+    erun("git add Cargo.lock")
     create_pr(c)
 
 


### PR DESCRIPTION
- Simplify clyde-store update
- Simplify create_pr
- Commit modified Cargo.lock
- Prevent creating tag if prep-release has not been merged
- Bump version number
