### PR TITLE
Make `clydetools add-assets` smarter when given several URLs

### DIFF
--- a/.changes/unreleased/Changed-20220906-232423.yaml
+++ b/.changes/unreleased/Changed-20220906-232423.yaml
@@ -1,0 +1,4 @@
+kind: Changed
+body: '`clydetools add-assets` and `clydetools fetch` no longer downloads more than
+  one URL per arch-os.'
+time: 2022-09-06T23:24:23.881681546+02:00


### PR DESCRIPTION
Only download one URL per arch-os, try to pick the best one.
