### PR TITLE
support any releases

### DIFF
--- a/.changes/unreleased/Added-20220928-084841.yaml
+++ b/.changes/unreleased/Added-20220928-084841.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: It is now possible for assets to be cross-os, cross-arch or both (#29).
+time: 2022-09-28T08:48:41.175669692+02:00

--- a/src/arch_os.rs
+++ b/src/arch_os.rs
@@ -9,6 +9,14 @@ use anyhow::{anyhow, Result};
 
 pub const ANY: &str = "any";
 
+pub const ARCH_X86_64: &str = "x86_64";
+pub const ARCH_X86: &str = "x86";
+pub const ARCH_AARCH64: &str = "aarch64";
+
+pub const OS_LINUX: &str = "linux";
+pub const OS_MACOS: &str = "macos";
+pub const OS_WINDOWS: &str = "windows";
+
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct ArchOs {
     pub arch: String,

--- a/src/arch_os.rs
+++ b/src/arch_os.rs
@@ -37,6 +37,20 @@ impl ArchOs {
         }
     }
 
+    pub fn with_any_arch(&self) -> ArchOs {
+        ArchOs {
+            arch: ANY.into(),
+            os: self.os.clone(),
+        }
+    }
+
+    pub fn with_any_os(&self) -> ArchOs {
+        ArchOs {
+            arch: self.arch.clone(),
+            os: ANY.into(),
+        }
+    }
+
     pub fn parse(text: &str) -> Result<ArchOs> {
         if text == ANY {
             return Ok(ArchOs::new(ANY, ANY));

--- a/src/bin/clydetools/add_assets.rs
+++ b/src/bin/clydetools/add_assets.rs
@@ -11,19 +11,13 @@ use anyhow::{anyhow, Result};
 use semver::Version;
 
 use clyde::app::App;
-use clyde::arch_os::{ArchOs, ANY};
+use clyde::arch_os::{
+    ArchOs, ANY, ARCH_AARCH64, ARCH_X86, ARCH_X86_64, OS_LINUX, OS_MACOS, OS_WINDOWS,
+};
 use clyde::checksum::compute_checksum;
 use clyde::file_cache::FileCache;
 use clyde::package::{Asset, Package, Release};
 use clyde::ui::Ui;
-
-const ARCH_X86_64: &str = "x86_64";
-const ARCH_X86: &str = "x86";
-const ARCH_AARCH64: &str = "aarch64";
-
-const OS_LINUX: &str = "linux";
-const OS_MACOS: &str = "macos";
-const OS_WINDOWS: &str = "windows";
 
 type MatchingPair = (&'static str, &'static str);
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -197,7 +197,23 @@ impl Package {
 
     pub fn get_asset(&self, version: &Version, arch_os: &ArchOs) -> Option<&Asset> {
         let release = self.releases.get(version)?;
-        release.get(arch_os)
+        let asset = release.get(arch_os);
+        if asset.is_some() {
+            return asset;
+        }
+        if arch_os.arch != ANY {
+            let asset = release.get(&arch_os.with_any_arch());
+            if asset.is_some() {
+                return asset;
+            }
+        }
+        if arch_os.os != ANY {
+            let asset = release.get(&arch_os.with_any_os());
+            if asset.is_some() {
+                return asset;
+            }
+        }
+        release.get(&ArchOs::new(ANY, ANY))
     }
 
     /// Return files definition for wanted_version
@@ -208,16 +224,14 @@ impl Package {
             return install;
         }
         if arch_os.arch != ANY {
-            let arch_os = ArchOs::new(ANY, &arch_os.os);
-            let install = self.get_install_internal(wanted_version, &arch_os);
+            let install = self.get_install_internal(wanted_version, &arch_os.with_any_arch());
             if install.is_some() {
                 return install;
             }
         }
         if arch_os.os != ANY {
             // Probably less useful than the previous check, but you never know
-            let arch_os = ArchOs::new(&arch_os.arch, ANY);
-            let install = self.get_install_internal(wanted_version, &arch_os);
+            let install = self.get_install_internal(wanted_version, &arch_os.with_any_os());
             if install.is_some() {
                 return install;
             }


### PR DESCRIPTION
This makes it possible to package cross-arch or cross-os applications. One example of these is git-filter-repo. This [matching clyde-store PR](https://github.com/agateau/clyde-store/pull/74) takes advantage of the changes from this PR (The clyde-store PR already passes, but that's because it can't find releases for any OS!)
