### PR TITLE
Add support for shipping extra files

### DIFF
--- a/.changes/unreleased/Package format change-20221031-190858.yaml
+++ b/.changes/unreleased/Package format change-20221031-190858.yaml
@@ -1,0 +1,4 @@
+kind: Package format change
+body: It is now possible to ship extra files with a package. This is useful to provide
+  icon or .desktop files (#9).
+time: 2022-10-31T19:08:58.463458137+01:00

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -15,10 +15,11 @@ The home location can be overridden using the `$CLYDE_HOME` environment variable
 ## Folder hierarchy
 
 - `$CLYDE_HOME`
-    - `inst`: where files are installed
+    - `inst`: Clyde "prefix": where files are installed
         - `bin`
         - `share`
-    - `download`: where clyde downloads assets
+        - `opt`
+    - `download`: where Clyde downloads assets
     - `store`: Clyde store (see below)
     - `scripts`: activation scripts
     - `tmp_dir`: used while installing

--- a/docs/package-file-format.md
+++ b/docs/package-file-format.md
@@ -4,6 +4,10 @@ This document describes the file format used by Clyde.
 
 Clyde packages are defined as YAML files.
 
+They can be either a plain file: `<package>.yaml`, or a directory: `<package>/index.yaml`.
+
+The directory format is supported since 0.4.0.
+
 ## Meta information
 
 ```yaml
@@ -52,13 +56,19 @@ releases:
 
 Next is the "installs" entry. This entry tells Clyde how to install the downloaded asset.
 
-`installs` is a mapping which contain entries for the supported versions. There is not necessarily one entry for each version: the `clyde install` command uses the entry with highest version which is lower than or equal to the version to install.
+`installs` is a mapping containing entries for the supported versions. There is not necessarily one entry for each version: the `clyde install` command uses the entry with the highest version which is lower than or equal to the version to install.
 
-This means that if a package have `installs` entries for version 1.2.0 and 1.3.0, then installing 1.3.4 would use the 1.3.0 entries. Installing 1.2.4 would use the 1.2.0 entries.
+This means that if a package has `installs` entries for version 1.2.0 and 1.3.0, then installing 1.3.4 would use the 1.3.0 entries. Installing 1.2.4 would use the 1.2.0 entries.
 
-Each version entry then contains arch-os entries. The arch and/or OS part can be set to `any` if install instructions are independent of the arch and/or the OS.
+Each version entry then contains arch-os entries. The arch and/or OS parts can be set to `any` if install instructions are independent of the arch and/or the OS.
 
-Each arch-os entry contain a `strip` entry and a `files` entry, as demonstrated below.
+Each arch-os entry can contain the following entries:
+
+- `files`: a mapping of files contained in the asset to the place where they should be installed. See below for more examples.
+- `strip` (optional): the number of directories to ignore inside the asset. For example if all files of foo-1.0.tar.gz are inside a `foo-1.0` directory, set `strip` to 1 to tell Clyde that all entries in `files` are *inside* this directory. Defaults to 0.
+- `extra_files` (optional, since 0.4.0): a mapping of files inside the package `extra_files` directory to the place where they should be installed.
+
+Here is an example of an `installs` entry:
 
 ```yaml
 installs:
@@ -94,14 +104,18 @@ installs:
         # expands to "share/doc/<package_name>/".
         # In this example "README.md" is copied to "share/doc/foobar/README.md".
         README.md: ${doc_dir}
+
+      extra_files:
+        # Copy "extra_files/bar" from within the package directory to "bin/bar"
+        bar: bin/
     any-macos:
       # macOS special instructions
 ```
 
 Packages must follow these rules:
 
-- install binaries in bin
-- install man pages in share/man
+- install binaries in `bin`
+- install man pages in `share/man`
 - install documentation in `share/doc/<package_name>` (use `${doc_dir}` for this, see "Variables" section)
 
 ### Variables

--- a/docs/package-file-format.md
+++ b/docs/package-file-format.md
@@ -4,7 +4,7 @@ This document describes the file format used by Clyde.
 
 Clyde packages are defined as YAML files.
 
-They can be either a plain file: `<package>.yaml`, or a directory: `<package>/index.yaml`.
+They can be either a directory: `<package_name>/index.yaml` or a plain file: `<package_name>.yaml`.
 
 The directory format is supported since 0.4.0.
 
@@ -66,7 +66,7 @@ Each arch-os entry can contain the following entries:
 
 - `files`: a mapping of files contained in the asset to the place where they should be installed. See below for more examples.
 - `strip` (optional): the number of directories to ignore inside the asset. For example if all files of foo-1.0.tar.gz are inside a `foo-1.0` directory, set `strip` to 1 to tell Clyde that all entries in `files` are *inside* this directory. Defaults to 0.
-- `extra_files` (optional, since 0.4.0): a mapping of files inside the package `extra_files` directory to the place where they should be installed.
+- `extra_files` (optional, since 0.4.0): the directory of a package using the directory format can contain an `extra_files` directory to provide files to install in addition to the asset files. This can be useful to provide launcher scripts, icons, or .desktop files. In this case this entry is a mapping of files from the `extra_files` directory to the place where they should be installed.
 
 Here is an example of an `installs` entry:
 
@@ -118,6 +118,8 @@ Packages must follow these rules:
 - install man pages in `share/man`
 - install documentation in `share/doc/<package_name>` (use `${doc_dir}` for this, see "Variables" section)
 
+If it is not possible to install the package files this way, then install all package files in `opt/<package_name>/`, add a launcher script to `extra_files` and install it in `bin`. Don't forget to make your launcher script executable.
+
 ### Variables
 
 The source and destination parts of the `files` mapping supports variables. A variable can be used with the `${variable_name}` syntax.
@@ -127,3 +129,7 @@ The following variables are available:
 - `${asset_name}`: Name of the unpacked asset if the asset is a single-file asset. A single-file asset is an asset which is either the package executable, or a compressed version of it, compressed with gzip, bzip2 or xz. This variable is only available if the asset is a single-file asset.
 - `${doc_dir}`: Directory storing the package documentation. Set to "share/doc/<package_name>/".
 - `${exe_ext}`: Executable extension for the target OS. Set to ".exe" on Windows and "" on other OSes.
+
+## Environment variables
+
+Clyde activation scripts define a `$CLYDE_INST_DIR` environment variable pointing to Clyde prefix. This means Clyde `opt` directory for example, can be referred to as `$CLYDE_INST_DIR/opt`. Launcher scripts installed via `extra_files` can make use of the `$CLYDE_INST_DIR` environment variable to refer to a file installed in `$CLYDE_INST_DIR/opt/<package_name>`.

--- a/src/activate.sh.tmpl
+++ b/src/activate.sh.tmpl
@@ -6,5 +6,7 @@ if [ "${BASH_SOURCE-}" = "$0" ]; then
     exit 12
 fi
 
-export PATH=@INSTALL_DIR@/bin:$PATH
-export MANPATH=@INSTALL_DIR@/share/man:${MANPATH:-}
+export CLYDE_INST_DIR="@INSTALL_DIR@"
+
+export PATH="$CLYDE_INST_DIR/bin:$PATH"
+export MANPATH="$CLYDE_INST_DIR/share/man:${MANPATH-}"

--- a/src/activate.sh.tmpl
+++ b/src/activate.sh.tmpl
@@ -10,3 +10,4 @@ export CLYDE_INST_DIR="@INSTALL_DIR@"
 
 export PATH="$CLYDE_INST_DIR/bin:$PATH"
 export MANPATH="$CLYDE_INST_DIR/share/man:${MANPATH-}"
+export XDG_DATA_DIRS="$CLYDE_INST_DIR/share:${XDG_DATA_DIRS-/usr/local/share:/usr/share}"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,11 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Setup Clyde
-    Setup {},
+    Setup {
+        /// Update the activation scripts of an existing installation.
+        #[clap(short, long)]
+        update_scripts: bool,
+    },
     /// Update Clyde store
     Update {},
     /// Install applications
@@ -80,7 +84,7 @@ impl Cli {
         let home = App::find_home(&ui)?;
 
         match self.command {
-            Command::Setup {} => setup(&ui, &home),
+            Command::Setup { update_scripts } => setup(&ui, &home, update_scripts),
             Command::Update {} => {
                 let app = App::new(&home)?;
                 update(&app, &ui)

--- a/src/package.rs
+++ b/src/package.rs
@@ -32,29 +32,6 @@ pub struct Install {
     pub files: BTreeMap<String, String>,
 }
 
-impl Install {
-    pub fn expanded(other: &Install) -> Install {
-        let files = other
-            .files
-            .iter()
-            .map(|(src, dst)| {
-                (
-                    src.clone(),
-                    if dst.is_empty() {
-                        src.clone()
-                    } else {
-                        dst.clone()
-                    },
-                )
-            })
-            .collect();
-        Install {
-            strip: other.strip,
-            files,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Package {
     pub name: String,
@@ -130,9 +107,7 @@ impl InternalPackage {
                 let version = Version::parse(version_str)?;
                 let installs_for_arch_os = installs_for_arch_os
                     .iter()
-                    .map(|(arch_os, install)| {
-                        (ArchOs::parse(arch_os).unwrap(), Install::expanded(install))
-                    })
+                    .map(|(arch_os, install)| (ArchOs::parse(arch_os).unwrap(), install.clone()))
                     .collect();
                 installs.insert(version, installs_for_arch_os);
             }
@@ -266,7 +241,7 @@ mod tests {
             install.files.get("bin/foo-1.2"),
             Some(&"bin/foo".to_string())
         );
-        assert_eq!(install.files.get("share"), Some(&"share".to_string()));
+        assert_eq!(install.files.get("share"), Some(&"".to_string()));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -12,7 +12,7 @@ use anyhow::{anyhow, Result};
 
 use crate::package::Package;
 
-const INDEX_NAME: &str = "index.yaml";
+pub const INDEX_NAME: &str = "index.yaml";
 
 #[derive(Clone)]
 pub struct SearchHit {

--- a/src/store.rs
+++ b/src/store.rs
@@ -12,6 +12,8 @@ use anyhow::{anyhow, Result};
 
 use crate::package::Package;
 
+const INDEX_NAME: &str = "index.yaml";
+
 #[derive(Clone)]
 pub struct SearchHit {
     pub name: String,
@@ -56,12 +58,34 @@ impl GitStore {
                 None
             };
         }
+        let store_path = self.dir.join(name).join(INDEX_NAME);
+        if store_path.is_file() {
+            return Some(store_path);
+        }
         let store_path = self.dir.join(name.to_owned() + ".yaml");
         if store_path.is_file() {
             return Some(store_path);
         }
         None
     }
+}
+
+/// Return path to the YAML file if it exists
+/// If path is a dir, returns <path>/index.yaml
+/// If path is a file, returns <path> if its extension is .yaml
+fn get_package_path(path: &Path) -> Option<PathBuf> {
+    if path.is_dir() {
+        let path = path.join(INDEX_NAME);
+        if path.exists() {
+            return Some(path);
+        } else {
+            return None;
+        }
+    }
+    if path.extension() != Some(&OsString::from("yaml")) {
+        return None;
+    }
+    Some(path.into())
 }
 
 impl Store for GitStore {
@@ -112,13 +136,14 @@ impl Store for GitStore {
 
         // This implementation is very inefficient, but it's good enough for now given the number
         // of available packages. It should be revisited when the number of packages grow.
-        // A possible solution is to create a database table to store the name and descriptions of
+        // A possible solution is to create a database table to store the name and description of
         // available packages.
         for entry in fs::read_dir(&self.dir)? {
             let path = entry?.path();
-            if path.extension() != Some(&OsString::from("yaml")) {
-                continue;
-            }
+            let path = match get_package_path(&path) {
+                Some(x) => x,
+                None => continue,
+            };
             let package = Package::from_file(&path).expect("Skipping invalid package");
 
             if package.name.to_lowercase().contains(&query) {
@@ -146,6 +171,27 @@ mod tests {
     }
 
     fn create_package_file_with_desc(dir: &Path, name: &str, desc: &str) {
+        let package_dir = dir.join(name);
+        fs::create_dir(&package_dir).unwrap();
+        let path = package_dir.join(INDEX_NAME);
+        fs::write(
+            path,
+            format!(
+                "
+        name: {name}
+        description: {desc}
+        homepage:
+        releases: {{}}
+        installs: {{}}
+        ",
+                name = name,
+                desc = desc
+            ),
+        )
+        .unwrap();
+    }
+
+    fn create_old_package_file_with_desc(dir: &Path, name: &str, desc: &str) {
         let path = dir.join(name.to_owned() + ".yaml");
         fs::write(
             path,
@@ -173,9 +219,9 @@ mod tests {
 
         create_package_file(&dir, "foo");
         create_package_file(&dir, "bar");
-        create_package_file_with_desc(&dir, "baz", "Helper package for Foo");
+        create_old_package_file_with_desc(&dir, "baz", "Helper package for Foo");
 
-        // WHEN I search for bar
+        // WHEN I search for fOo
         let results = store.search("fOo").unwrap();
 
         // THEN foo and baz should be returned


### PR DESCRIPTION
This PR implements #9: it makes it possible to install extra files to complement the package files.

This is useful to add icon or .desktop entries.

It also opens the way to ship other files, like a package-specific script that `clydetools fetch` could use.

Closes #9.