### PR TITLE
Make sure there is only one instance running at a time

### DIFF
--- a/.changes/unreleased/Fixed-20221115-093346.yaml
+++ b/.changes/unreleased/Fixed-20221115-093346.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: Clyde now ensures only one command is running at a time on a given installation
+  (#3).
+time: 2022-11-15T09:33:46.456930192+01:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "shell-words",
+ "single-instance",
  "tempfile",
  "which",
  "zip 0.6.2",
@@ -821,6 +822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +855,19 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1287,6 +1310,19 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "single-instance"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4637485391f8545c9d3dbf60f9d9aab27a90c789a700999677583bcb17c8795d"
+dependencies = [
+ "libc",
+ "nix",
+ "thiserror",
+ "widestring",
+ "winapi",
+]
 
 [[package]]
 name = "slab"
@@ -1739,6 +1775,12 @@ dependencies = [
  "libc",
  "once_cell",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ indicatif = "0.17.0"
 console = { version = "0.15.1", default-features = false, features = ["ansi-parsing"] }
 regex = "1.6.0"
 archiver-rs = { version = "0.5.1", default-features = false, features = ["bzip", "gzip", "xz"] }
+single-instance = "0.3.3"
 
 [dev-dependencies]
 assert_fs = "1.0.7"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -83,6 +83,8 @@ impl Cli {
         let ui = Ui::default();
         let home = App::find_home(&ui)?;
 
+        let _instance = App::create_single_instance(&home)?;
+
         match self.command {
             Command::Setup { update_scripts } => setup(&ui, &home, update_scripts),
             Command::Update {} => {


### PR DESCRIPTION
The check is done using Clyde home dir, so running two commands against
separate installations is OK.

Fixes #3
