### PR TITLE
Switch to dtolnay/rust-toolchain action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          override: true
 
       - name: Run static checks
         run: ci/run-static-checks
@@ -53,10 +52,9 @@ jobs:
         run: git fetch --force --tags
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          override: true
 
       - name: Build
         run: ci/build-app

--- a/ci/build-app
+++ b/ci/build-app
@@ -11,7 +11,8 @@ setup_cross() {
     CARGO_CMD=$(command -v cross || true)
     if [ -z "$CARGO_CMD" ] ; then
         echo "Installing cross $CROSS_VERSION"
-        cargo install cross --version $CROSS_VERSION
+        # Use --locked because of https://github.com/cross-rs/cross/issues/1177
+        cargo install cross --version $CROSS_VERSION --locked
     fi
     CARGO_CMD=$(command -v cross || true)
     if [ -z "$CARGO_CMD" ] ; then


### PR DESCRIPTION
action-rs is unmaintained and started to break today because of
<https://github.com/cross-rs/cross/issues/1177>.
