### PR TITLE
shallow clone store

### DIFF
--- a/.changes/unreleased/Added-20230131-092600.yaml
+++ b/.changes/unreleased/Added-20230131-092600.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: "`clyde setup` learned the `--url` option to define the URL of the store."
+time: 2023-01-31T09:26:00.632000844+01:00

--- a/.changes/unreleased/Changed-20230131-091054.yaml
+++ b/.changes/unreleased/Changed-20230131-091054.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '`clyde setup` now creates a shallow clone of the store, making it faster (#17).'
+time: 2023-01-31T09:10:54.728386631+01:00

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,8 +18,6 @@ use crate::file_cache::FileCache;
 use crate::store::{GitStore, Store};
 use crate::ui::Ui;
 
-const CLYDE_STORE_URL: &str = "https://github.com/agateau/clyde-store";
-
 pub struct App {
     pub download_cache: FileCache,
     pub home: PathBuf,
@@ -75,7 +73,7 @@ impl App {
             ));
         }
         let store_dir = home.join("store");
-        let store = GitStore::new(CLYDE_STORE_URL, &store_dir);
+        let store = GitStore::new(&store_dir);
 
         let db_path = home.join("clyde.sqlite");
         let database = Database::new_from_path(&db_path)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,9 @@ enum Command {
         /// Update the activation scripts of an existing installation.
         #[clap(short, long)]
         update_scripts: bool,
+        /// URL of the Git repository to use for the store.
+        #[clap(long = "--url")]
+        store_url: Option<String>,
     },
     /// Update Clyde store
     Update {},
@@ -86,7 +89,10 @@ impl Cli {
         let _instance = App::create_single_instance(&home)?;
 
         match self.command {
-            Command::Setup { update_scripts } => setup(&ui, &home, update_scripts),
+            Command::Setup {
+                update_scripts,
+                store_url,
+            } => setup(&ui, &home, update_scripts, store_url.as_deref()),
             Command::Update {} => {
                 let app = App::new(&home)?;
                 update(&app, &ui)

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -16,6 +16,8 @@ use crate::ui::Ui;
 
 const SH_INIT: &str = include_str!("activate.sh.tmpl");
 
+const CLYDE_STORE_URL: &str = "https://github.com/agateau/clyde-store";
+
 fn posix_shell_path_from_path(path: &Path) -> String {
     quote(path.to_str().unwrap()).to_string()
 }
@@ -84,7 +86,7 @@ pub fn setup(ui: &Ui, home: &Path, update_scripts: bool) -> Result<()> {
 
     let app = App::new(home)?;
 
-    app.store.setup()?;
+    app.store.setup(CLYDE_STORE_URL)?;
 
     ui.info("Creating Clyde database");
     app.database.create()?;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -71,10 +71,12 @@ fn update_activate_script(ui: &Ui, home: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn setup(ui: &Ui, home: &Path, update_scripts: bool) -> Result<()> {
+pub fn setup(ui: &Ui, home: &Path, update_scripts: bool, url: Option<&str>) -> Result<()> {
     if update_scripts {
         return update_activate_script(ui, home);
     }
+
+    let url = url.unwrap_or(CLYDE_STORE_URL);
 
     if home.exists() {
         return Err(anyhow!("Clyde directory ({:?}) already exists, not doing anything. Delete it if you want to start over.",
@@ -86,7 +88,8 @@ pub fn setup(ui: &Ui, home: &Path, update_scripts: bool) -> Result<()> {
 
     let app = App::new(home)?;
 
-    app.store.setup(CLYDE_STORE_URL)?;
+    ui.info(&format!("Cloning Clyde store from {}", &url));
+    app.store.setup(url)?;
 
     ui.info("Creating Clyde database");
     app.database.create()?;

--- a/src/store.rs
+++ b/src/store.rs
@@ -21,14 +21,13 @@ pub struct SearchHit {
 }
 
 pub trait Store {
-    fn setup(&self) -> Result<()>;
+    fn setup(&self, url: &str) -> Result<()>;
     fn update(&self) -> Result<()>;
     fn get_package(&self, name: &str) -> Result<Package>;
     fn search(&self, query: &str) -> Result<Vec<SearchHit>>;
 }
 
 pub struct GitStore {
-    url: String,
     dir: PathBuf,
 }
 
@@ -42,9 +41,8 @@ impl SearchHit {
 }
 
 impl GitStore {
-    pub fn new(url: &str, dir: &Path) -> GitStore {
+    pub fn new(dir: &Path) -> GitStore {
         GitStore {
-            url: url.to_string(),
             dir: dir.to_path_buf(),
         }
     }
@@ -89,9 +87,9 @@ fn get_package_path(path: &Path) -> Option<PathBuf> {
 }
 
 impl Store for GitStore {
-    fn setup(&self) -> Result<()> {
+    fn setup(&self, url: &str) -> Result<()> {
         let mut cmd = Command::new("git");
-        cmd.args(["clone", "--depth", "1", &self.url]);
+        cmd.args(["clone", "--depth", "1", url]);
         cmd.arg(self.dir.as_os_str());
 
         let status = match cmd.status() {
@@ -215,7 +213,7 @@ mod tests {
         let dir = assert_fs::TempDir::new().unwrap();
 
         // GIVEN a store with 3 packages foo, bar and baz (whose description contains Foo)
-        let store = GitStore::new("https://example.com", &dir);
+        let store = GitStore::new(&dir);
 
         create_package_file(&dir, "foo");
         create_package_file(&dir, "bar");
@@ -235,7 +233,7 @@ mod tests {
         // GIVEN an empty store
         let dir = assert_fs::TempDir::new().unwrap();
         let store_dir = dir.join("store");
-        let store = GitStore::new("https://example.com", &store_dir);
+        let store = GitStore::new(&store_dir);
 
         // AND a file called foo in the current dir
         fs::write(dir.join("foo"), "").unwrap();

--- a/src/store.rs
+++ b/src/store.rs
@@ -91,7 +91,7 @@ fn get_package_path(path: &Path) -> Option<PathBuf> {
 impl Store for GitStore {
     fn setup(&self) -> Result<()> {
         let mut cmd = Command::new("git");
-        cmd.args(["clone", &self.url]);
+        cmd.args(["clone", "--depth", "1", &self.url]);
         cmd.arg(self.dir.as_os_str());
 
         let status = match cmd.status() {

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -80,7 +80,7 @@ mod tests {
     }
 
     impl Store for FakeStore {
-        fn setup(&self) -> Result<()> {
+        fn setup(&self, _url: &str) -> Result<()> {
             Ok(())
         }
         fn update(&self) -> Result<()> {


### PR DESCRIPTION
- Speed up setup
- refactor: do not keep the store url in GitStore
- One can now define the store URL using `clyde setup --url STORE_URL`
