### PR TITLE
Make setup install clyde

### DIFF
--- a/.changes/unreleased/Changed-20230328-232630.yaml
+++ b/.changes/unreleased/Changed-20230328-232630.yaml
@@ -1,0 +1,4 @@
+kind: Changed
+body: '`clyde setup` now installs clyde itself inside the newly created Clyde home,
+  making initial setup simpler (#149).'
+time: 2023-03-28T23:26:30.576412103+02:00

--- a/.changes/unreleased/Deprecated-20230328-232739.yaml
+++ b/.changes/unreleased/Deprecated-20230328-232739.yaml
@@ -1,0 +1,4 @@
+kind: Deprecated
+body: "The `$CLYDE_INST_DIR` environment variable is now deprecated. `$CLYDE_HOME` is now defined by the activation script, so one can use `$CLYDE_HOME/inst`
+  instead."
+time: 2023-03-28T23:27:39.854183487+02:00

--- a/docs/package-file-format.md
+++ b/docs/package-file-format.md
@@ -160,4 +160,4 @@ This fetcher accepts the following entries:
 
 ## Environment variables
 
-Clyde activation scripts define a `$CLYDE_INST_DIR` environment variable pointing to Clyde prefix. This means Clyde `opt` directory for example, can be referred to as `$CLYDE_INST_DIR/opt`. Launcher scripts installed via `extra_files` can make use of the `$CLYDE_INST_DIR` environment variable to refer to a file installed in `$CLYDE_INST_DIR/opt/<package_name>`.
+Clyde activation script defines a `$CLYDE_HOME` environment variable pointing to Clyde home. This means Clyde `opt` directory for example, can be referred to as `$CLYDE_HOME/inst/opt`. Launcher scripts installed via `extra_files` can make use of the `$CLYDE_HOME` environment variable to refer to a file installed in `$CLYDE_HOME/inst/opt/<package_name>`.

--- a/functests/test_setup.py
+++ b/functests/test_setup.py
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from conftest import run_clyde
+from pathlib import Path
+
+from conftest import get_bin_path, run_clyde, run_in_clyde_home, IS_WINDOWS
 
 
 def test_install_without_setup_show_message(monkeypatch):
@@ -17,3 +19,17 @@ def test_install_without_setup_show_message(monkeypatch):
 
     # AND the error message suggests running `clyde setup`
     assert "clyde setup" in result.stderr
+
+
+def test_setup_installed_clyde(clyde_home):
+    # GIVEN an installed Clyde home
+    # WHEN calling `which clyde`
+    if IS_WINDOWS:
+        cmd = "cygpath -w $(which clyde)"
+    else:
+        cmd = "which clyde"
+    proc = run_in_clyde_home(cmd)
+
+    # THEN it returns the clyde binary inside Clyde home
+    clyde_path = Path(proc.stdout.strip())
+    assert clyde_path == get_bin_path("clyde")

--- a/src/activate.sh.tmpl
+++ b/src/activate.sh.tmpl
@@ -13,6 +13,7 @@ _clyde_setup() {
     export MANPATH="$inst_dir/share/man:${MANPATH-}"
     export XDG_DATA_DIRS="$inst_dir/share:${XDG_DATA_DIRS-/usr/local/share:/usr/share}"
 
+    # TODO remove once this variable has been deprecated
     export CLYDE_INST_DIR=$inst_dir
 
     case "$SHELL" in

--- a/src/activate.sh.tmpl
+++ b/src/activate.sh.tmpl
@@ -6,16 +6,23 @@ if [ "${BASH_SOURCE-}" = "$0" ]; then
     exit 12
 fi
 
-export CLYDE_INST_DIR="@INSTALL_DIR@"
+_clyde_setup() {
+    local inst_dir=$CLYDE_HOME/inst
 
-export PATH="$CLYDE_INST_DIR/bin:$PATH"
-export MANPATH="$CLYDE_INST_DIR/share/man:${MANPATH-}"
-export XDG_DATA_DIRS="$CLYDE_INST_DIR/share:${XDG_DATA_DIRS-/usr/local/share:/usr/share}"
+    export PATH="$inst_dir/bin:$PATH"
+    export MANPATH="$inst_dir/share/man:${MANPATH-}"
+    export XDG_DATA_DIRS="$inst_dir/share:${XDG_DATA_DIRS-/usr/local/share:/usr/share}"
 
-case "$SHELL" in
-    */zsh)
-        fpath=($CLYDE_INST_DIR/share/zsh-completions $fpath)
-        ;;
-    *)
-        ;;
-esac
+    export CLYDE_INST_DIR=$inst_dir
+
+    case "$SHELL" in
+        */zsh)
+            fpath=($inst_dir/share/zsh-completions $fpath)
+            ;;
+        *)
+            ;;
+    esac
+}
+
+export CLYDE_HOME="@CLYDE_HOME@"
+_clyde_setup

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,6 @@ use single_instance::SingleInstance;
 use crate::db::Database;
 use crate::file_cache::FileCache;
 use crate::store::{GitStore, Store};
-use crate::ui::Ui;
 
 pub struct App {
     pub download_cache: FileCache,
@@ -37,9 +36,8 @@ fn create_single_instance_name(home: &Path) -> String {
 }
 
 impl App {
-    pub fn find_home(ui: &Ui) -> Result<PathBuf> {
+    pub fn find_home() -> Result<PathBuf> {
         if let Some(home) = env::var_os("CLYDE_HOME") {
-            ui.info(&format!("Using {home:?} as Clyde home directory"));
             return Ok(Path::new(&home).to_path_buf());
         }
 
@@ -50,7 +48,7 @@ impl App {
         Err(anyhow!("Could not find Clyde home directory"))
     }
 
-    /// Make sure that for a given home directory, only one instance of Clippy is running at a time
+    /// Make sure that for a given home directory, only one instance of Clyde is running at a time
     pub fn create_single_instance(home: &Path) -> Result<SingleInstance> {
         let name = create_single_instance_name(home);
 

--- a/src/bin/clydetools/main.rs
+++ b/src/bin/clydetools/main.rs
@@ -71,7 +71,7 @@ enum Command {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let ui = Ui::default();
-    let home = App::find_home(&ui)?;
+    let home = App::find_home()?;
 
     match cli.command {
         Command::AddAssets {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,7 +87,7 @@ struct GlobalOpts {
 impl Cli {
     pub fn exec(self) -> Result<()> {
         let ui = Ui::default();
-        let home = App::find_home(&ui)?;
+        let home = App::find_home()?;
 
         let _instance = App::create_single_instance(&home)?;
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -9,9 +9,11 @@ use std::path::Path;
 use std::process::Command;
 
 use anyhow::{anyhow, Result};
+use semver::VersionReq;
 use shell_words::quote;
 
 use crate::app::App;
+use crate::install::install_with_package_and_requested_version;
 use crate::ui::Ui;
 
 const SH_INIT: &str = include_str!("activate.sh.tmpl");
@@ -93,6 +95,14 @@ pub fn setup(ui: &Ui, home: &Path, update_scripts: bool, url: Option<&str>) -> R
 
     ui.info("Creating Clyde database");
     app.database.create()?;
+
+    install_with_package_and_requested_version(
+        &app,
+        ui,
+        false, /* reinstall */
+        "clyde",
+        &VersionReq::STAR,
+    )?;
 
     ui.info("Creating activation script");
     let shell_script_path = create_activate_script(&app)?;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -53,8 +53,8 @@ fn shell_path_from_path(path: &Path) -> Result<String> {
 }
 
 fn create_activate_script(app: &App) -> Result<String> {
-    let install_dir = shell_path_from_path(&app.install_dir)?;
-    let content = SH_INIT.replace("@INSTALL_DIR@", &install_dir);
+    let clyde_home = shell_path_from_path(&app.home)?;
+    let content = SH_INIT.replace("@CLYDE_HOME@", &clyde_home);
 
     let scripts_dir = app.home.join("scripts");
     let script_path = scripts_dir.join("activate.sh");


### PR DESCRIPTION
- Make `clyde setup` install clyde
- Fix clyde commands not always refering to the install from the Clyde home
- Deprecate CLYDE_INST_DIR
- Add changelog entries

Fixes #149.