### PR TITLE
update clyde alone

### DIFF
--- a/.changes/unreleased/Changed-20230401-135451.yaml
+++ b/.changes/unreleased/Changed-20230401-135451.yaml
@@ -1,0 +1,4 @@
+kind: Changed
+body: 'When a new version of Clyde is available, `clyde upgrade` won''t install any
+  other package than the `clyde` package, ensuring install or upgrade of packages are done with the latest versio of Clyde'
+time: 2023-04-01T13:54:51.727541827+02:00

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macos-11
           - windows-2019
 

--- a/functests/test_upgrade.py
+++ b/functests/test_upgrade.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2023 Aurélien Gâteau <mail@agateau.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+import sqlite3
+from pathlib import Path
+
+from conftest import run_clyde
+
+
+def _get_db_connection():
+    db_path = Path(os.environ["CLYDE_HOME"], "clyde.sqlite")
+    assert db_path.exists(), db_path
+    return sqlite3.connect(db_path)
+
+
+def set_package_version(name: str, version: str) -> None:
+    conn = _get_db_connection()
+    conn.execute(
+        """update installed_package
+        set installed_version=?
+        where name=?""",
+        (version, name),
+    )
+    conn.commit()
+
+
+def add_installed_package(name: str, version: str) -> None:
+    conn = _get_db_connection()
+    conn.execute(
+        """insert into installed_package(name, installed_version, requested_version)
+        values(?, ?, '*')""",
+        (name, version),
+    )
+    conn.commit()
+
+
+def get_package_version(name: str) -> str:
+    conn = _get_db_connection()
+    res = conn.execute(
+        """select installed_version
+        from installed_package
+        where name=?""",
+        (name,),
+    )
+    return res.fetchone()[0]
+
+
+def test_upgrade_install_clyde_only(clyde_home):
+    # GIVEN a Clyde home
+    # AND an outdated clyde install
+    set_package_version("clyde", "0.1.0")
+
+    # AND an outdated starship install
+    add_installed_package("starship", "0.1.0")
+
+    # WHEN `clyde upgrade` runs
+    result = run_clyde("upgrade")
+
+    # THEN it only upgrades clyde
+    assert get_package_version("clyde") != "0.1.0"
+    assert get_package_version("starship") == "0.1.0"

--- a/src/bin/clydetools/fetch.rs
+++ b/src/bin/clydetools/fetch.rs
@@ -60,7 +60,7 @@ impl FetcherFinder {
     }
 }
 
-pub fn fetch(app: &App, ui: &Ui, paths: &[PathBuf]) -> Result<()> {
+pub fn fetch_cmd(app: &App, ui: &Ui, paths: &[PathBuf]) -> Result<()> {
     let fetcher_finder = FetcherFinder::new();
 
     for path in paths {

--- a/src/bin/clydetools/main.rs
+++ b/src/bin/clydetools/main.rs
@@ -23,7 +23,7 @@ use clyde::ui::Ui;
 
 use add_assets::add_assets_cmd;
 use check_package::check_packages;
-use fetch::fetch;
+use fetch::fetch_cmd;
 
 /// Helper tools for Clyde package authors. These commands are not useful to use Clyde.
 #[derive(Debug, Parser)]
@@ -87,7 +87,7 @@ fn main() -> Result<()> {
         Command::Check { package_files } => check_packages(&ui, &package_files),
         Command::Fetch { package_files } => {
             let app = App::new(&home)?;
-            fetch(&app, &ui, &package_files)
+            fetch_cmd(&app, &ui, &package_files)
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,15 +6,15 @@ use anyhow::Result;
 use clap::{ArgAction, Args, Parser, Subcommand};
 
 use crate::app::App;
-use crate::install::install;
-use crate::list::list;
-use crate::search::search;
-use crate::setup::setup;
-use crate::show::show;
+use crate::install::install_cmd;
+use crate::list::list_cmd;
+use crate::search::search_cmd;
+use crate::setup::setup_cmd;
+use crate::show::show_cmd;
 use crate::ui::Ui;
-use crate::uninstall::uninstall;
-use crate::update::update;
-use crate::upgrade::upgrade;
+use crate::uninstall::uninstall_cmd;
+use crate::update::update_cmd;
+use crate::upgrade::upgrade_cmd;
 
 #[derive(Debug, Parser)]
 #[command(name = "clyde", version, about)]
@@ -95,37 +95,37 @@ impl Cli {
             Command::Setup {
                 update_scripts,
                 store_url,
-            } => setup(&ui, &home, update_scripts, store_url.as_deref()),
+            } => setup_cmd(&ui, &home, update_scripts, store_url.as_deref()),
             Command::Update {} => {
                 let app = App::new(&home)?;
-                update(&app, &ui)
+                update_cmd(&app, &ui)
             }
             Command::Install {
                 reinstall,
                 package_names,
             } => {
                 let app = App::new(&home)?;
-                install(&app, &ui, reinstall, &package_names)
+                install_cmd(&app, &ui, reinstall, &package_names)
             }
             Command::Uninstall { package_names } => {
                 let app = App::new(&home)?;
-                uninstall(&app, &ui, &package_names)
+                uninstall_cmd(&app, &ui, &package_names)
             }
             Command::Show { package_name, list } => {
                 let app = App::new(&home)?;
-                show(&app, &package_name, list)
+                show_cmd(&app, &package_name, list)
             }
             Command::Search { query } => {
                 let app = App::new(&home)?;
-                search(&app, &query)
+                search_cmd(&app, &query)
             }
             Command::List {} => {
                 let app = App::new(&home)?;
-                list(&app)
+                list_cmd(&app)
             }
             Command::Upgrade {} => {
                 let app = App::new(&home)?;
-                upgrade(&app, &ui)
+                upgrade_cmd(&app, &ui)
             }
         }
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -166,7 +166,12 @@ fn create_vars_map(asset_name: &Option<String>, package_name: &str) -> VarsMap {
     map
 }
 
-pub fn install(app: &App, ui: &Ui, reinstall: bool, package_name_args: &Vec<String>) -> Result<()> {
+pub fn install_cmd(
+    app: &App,
+    ui: &Ui,
+    reinstall: bool,
+    package_name_args: &Vec<String>,
+) -> Result<()> {
     for package_name_arg in package_name_args {
         let (package_name, requested_version) = parse_package_name_arg(package_name_arg)?;
         install_with_package_and_requested_version(

--- a/src/install.rs
+++ b/src/install.rs
@@ -17,6 +17,8 @@ use crate::uninstall::uninstall_package;
 use crate::unpacker::get_unpacker;
 use crate::vars::{expand_vars, VarsMap};
 
+const CLYDE_PACKAGE_NAME: &str = "clyde";
+
 #[derive(Debug, PartialEq)]
 /// Store the details of an install, used by install_package()
 /// and install_packages()
@@ -202,6 +204,14 @@ pub fn install_packages(
     reinstall: bool,
     install_requests: &Vec<InstallRequest>,
 ) -> Result<()> {
+    if let Some(clyde_request) = install_requests
+        .iter()
+        .find(|x| x.name == CLYDE_PACKAGE_NAME)
+    {
+        ui.warn("The list of packages to install/upgrade includes Clyde itself. To avoid issues, only Clyde is going to be updated. You need to rerun the command after it's installed.");
+        return install_package(app, ui, reinstall, clyde_request);
+    }
+
     for request in install_requests {
         install_package(app, ui, reinstall, request)?;
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -174,18 +174,12 @@ pub fn install_cmd(
 ) -> Result<()> {
     for package_name_arg in package_name_args {
         let (package_name, requested_version) = parse_package_name_arg(package_name_arg)?;
-        install_with_package_and_requested_version(
-            app,
-            ui,
-            reinstall,
-            package_name,
-            &requested_version,
-        )?;
+        install_package(app, ui, reinstall, package_name, &requested_version)?;
     }
     Ok(())
 }
 
-pub fn install_with_package_and_requested_version(
+pub fn install_package(
     app: &App,
     ui: &Ui,
     reinstall: bool,

--- a/src/install.rs
+++ b/src/install.rs
@@ -17,6 +17,23 @@ use crate::uninstall::uninstall_package;
 use crate::unpacker::get_unpacker;
 use crate::vars::{expand_vars, VarsMap};
 
+#[derive(Debug, PartialEq)]
+/// Store the details of an install, used by install_package()
+/// and install_packages()
+pub struct InstallRequest {
+    pub name: String,
+    pub version: VersionReq,
+}
+
+impl InstallRequest {
+    pub fn new(package_name: &str, version: VersionReq) -> Self {
+        InstallRequest {
+            name: package_name.into(),
+            version,
+        }
+    }
+}
+
 fn unpack(archive: &Path, pkg_dir: &Path, strip: u32) -> Result<Option<String>> {
     let unpacker = get_unpacker(archive)?;
     unpacker.unpack(pkg_dir, strip)
@@ -127,15 +144,15 @@ fn install_files(
     Ok(())
 }
 
-fn parse_package_name_arg(arg: &str) -> Result<(&str, VersionReq)> {
+fn parse_package_name_arg(arg: &str) -> Result<InstallRequest> {
     let split = arg.split_once('@');
     match split {
-        None => Ok((arg, VersionReq::STAR)),
+        None => Ok(InstallRequest::new(arg, VersionReq::STAR)),
         Some((name, requested_str)) => {
             let version = VersionReq::parse(requested_str).with_context(|| {
-                format!("Failed to parse requested version ('{requested_str}')")
+                format!("Failed to parse requested version ('{requested_str}') from '{arg}'")
             })?;
-            Ok((name, version))
+            Ok(InstallRequest::new(name, version))
         }
     }
 }
@@ -170,11 +187,23 @@ pub fn install_cmd(
     app: &App,
     ui: &Ui,
     reinstall: bool,
-    package_name_args: &Vec<String>,
+    package_name_args: &[String],
 ) -> Result<()> {
-    for package_name_arg in package_name_args {
-        let (package_name, requested_version) = parse_package_name_arg(package_name_arg)?;
-        install_package(app, ui, reinstall, package_name, &requested_version)?;
+    let install_requests = package_name_args
+        .iter()
+        .map(|name| parse_package_name_arg(name))
+        .collect::<Result<Vec<InstallRequest>>>()?;
+    install_packages(app, ui, reinstall, &install_requests)
+}
+
+pub fn install_packages(
+    app: &App,
+    ui: &Ui,
+    reinstall: bool,
+    install_requests: &Vec<InstallRequest>,
+) -> Result<()> {
+    for request in install_requests {
+        install_package(app, ui, reinstall, request)?;
     }
     Ok(())
 }
@@ -183,20 +212,20 @@ pub fn install_package(
     app: &App,
     ui: &Ui,
     reinstall: bool,
-    package_path: &str,
-    requested_version: &VersionReq,
+    install_request: &InstallRequest,
 ) -> Result<()> {
     let db = &app.database;
 
     let arch_os = ArchOs::current();
 
-    let package = app.store.get_package(package_path)?;
+    let package = app.store.get_package(&install_request.name)?;
 
     let version = package
-        .get_version_matching(requested_version)
+        .get_version_matching(&install_request.version)
         .ok_or_else(|| {
             anyhow!(
-                "No version matching '{requested_version}' available for {}",
+                "No version matching '{}' available for {}",
+                &install_request.version,
                 &package.name
             )
         })?;
@@ -272,7 +301,12 @@ pub fn install_package(
             &map,
         )?;
     }
-    db.add_package(&package.name, version, requested_version, &installed_files)?;
+    db.add_package(
+        &package.name,
+        version,
+        &install_request.version,
+        &installed_files,
+    )?;
 
     ui.info("Cleaning");
     fs::remove_dir_all(&unpack_dir)
@@ -293,15 +327,15 @@ mod tests {
     fn test_parse_package_name_arg() {
         assert_eq!(
             parse_package_name_arg("foo").unwrap(),
-            ("foo", VersionReq::STAR)
+            InstallRequest::new("foo", VersionReq::STAR)
         );
         assert_eq!(
             parse_package_name_arg("foo@1.2").unwrap(),
-            ("foo", VersionReq::parse("1.2").unwrap())
+            InstallRequest::new("foo", VersionReq::parse("1.2").unwrap())
         );
         assert_eq!(
             parse_package_name_arg("foo@1.*").unwrap(),
-            ("foo", VersionReq::parse("1.*").unwrap())
+            InstallRequest::new("foo", VersionReq::parse("1.*").unwrap())
         );
     }
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use crate::app::App;
 use crate::table::Table;
 
-pub fn list(app: &App) -> Result<()> {
+pub fn list_cmd(app: &App) -> Result<()> {
     let table = Table::new(&[40, 12, 12]);
     table.add_row(&["Package", "Installed", "Requested"]);
     table.add_separator();

--- a/src/search.rs
+++ b/src/search.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 use crate::app::App;
 
-pub fn search(app: &App, query: &str) -> Result<()> {
+pub fn search_cmd(app: &App, query: &str) -> Result<()> {
     let results = app.store.search(query)?;
     if results.is_empty() {
         eprintln!("No packages found matching '{query}'");

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -73,7 +73,7 @@ fn update_activate_script(ui: &Ui, home: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn setup(ui: &Ui, home: &Path, update_scripts: bool, url: Option<&str>) -> Result<()> {
+pub fn setup_cmd(ui: &Ui, home: &Path, update_scripts: bool, url: Option<&str>) -> Result<()> {
     if update_scripts {
         return update_activate_script(ui, home);
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -13,7 +13,7 @@ use semver::VersionReq;
 use shell_words::quote;
 
 use crate::app::App;
-use crate::install::install_with_package_and_requested_version;
+use crate::install::install_package;
 use crate::ui::Ui;
 
 const SH_INIT: &str = include_str!("activate.sh.tmpl");
@@ -96,7 +96,7 @@ pub fn setup_cmd(ui: &Ui, home: &Path, update_scripts: bool, url: Option<&str>) 
     ui.info("Creating Clyde database");
     app.database.create()?;
 
-    install_with_package_and_requested_version(
+    install_package(
         &app,
         ui,
         false, /* reinstall */

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -13,7 +13,7 @@ use semver::VersionReq;
 use shell_words::quote;
 
 use crate::app::App;
-use crate::install::install_package;
+use crate::install::{install_package, InstallRequest};
 use crate::ui::Ui;
 
 const SH_INIT: &str = include_str!("activate.sh.tmpl");
@@ -100,8 +100,7 @@ pub fn setup_cmd(ui: &Ui, home: &Path, update_scripts: bool, url: Option<&str>) 
         &app,
         ui,
         false, /* reinstall */
-        "clyde",
-        &VersionReq::STAR,
+        &InstallRequest::new("clyde", VersionReq::STAR),
     )?;
 
     ui.info("Creating activation script");

--- a/src/show.rs
+++ b/src/show.rs
@@ -40,7 +40,7 @@ fn show_files(app: &App, package_name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn show(app: &App, app_name: &str, list: bool) -> Result<()> {
+pub fn show_cmd(app: &App, app_name: &str, list: bool) -> Result<()> {
     if list {
         show_files(app, app_name)
     } else {

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -26,7 +26,7 @@ fn path_exists(path: &Path) -> bool {
     path.is_symlink() || path.exists()
 }
 
-pub fn uninstall(app: &App, ui: &Ui, package_names: &Vec<String>) -> Result<()> {
+pub fn uninstall_cmd(app: &App, ui: &Ui, package_names: &Vec<String>) -> Result<()> {
     for package_name in package_names {
         uninstall_package(app, ui, package_name)?;
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use crate::app::App;
 use crate::ui::Ui;
 
-pub fn update(app: &App, ui: &Ui) -> Result<()> {
+pub fn update_cmd(app: &App, ui: &Ui) -> Result<()> {
     ui.info("Updating Clyde store");
     app.store.update()
 }

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -7,13 +7,13 @@ use std::vec::Vec;
 use anyhow::Result;
 
 use crate::app::App;
-use crate::db::{Database, PackageInfo};
-use crate::install::install_package;
+use crate::db::Database;
+use crate::install::{install_packages, InstallRequest};
 use crate::store::Store;
 use crate::ui::Ui;
 
-fn get_upgrades(ui: &Ui, store: &dyn Store, db: &Database) -> Result<Vec<PackageInfo>> {
-    let mut upgrades = Vec::<PackageInfo>::new();
+fn get_upgrades(ui: &Ui, store: &dyn Store, db: &Database) -> Result<Vec<InstallRequest>> {
+    let mut upgrades = Vec::<InstallRequest>::new();
 
     for info in db.get_installed_packages()? {
         let package = match store.get_package(&info.name) {
@@ -25,7 +25,7 @@ fn get_upgrades(ui: &Ui, store: &dyn Store, db: &Database) -> Result<Vec<Package
         };
         if let Some(available_version) = package.get_version_matching(&info.requested_version) {
             if available_version > &info.installed_version {
-                upgrades.push(info);
+                upgrades.push(InstallRequest::new(&info.name, info.requested_version));
             }
         }
     }
@@ -39,20 +39,8 @@ pub fn upgrade_cmd(app: &App, ui: &Ui) -> Result<()> {
         ui.info("No packages to upgrade");
         return Ok(());
     }
-    for info in to_upgrade {
-        ui.info(&format!("Upgrading {}", info.name));
-        install_package(
-            app,
-            &ui.nest(),
-            false, /* reinstall */
-            &info.name,
-            &info.requested_version,
-        )
-        .unwrap_or_else(|x| {
-            ui.error(&format!("Error: Failed to upgrade {}: {}", info.name, x));
-        });
-    }
-    Ok(())
+
+    install_packages(app, ui, false /* reinstall */, &to_upgrade)
 }
 
 #[cfg(test)]
@@ -209,13 +197,6 @@ mod tests {
         let upgrades = get_upgrades(&Ui::default(), &store, &db).unwrap();
 
         // THEN it returns foo
-        assert_eq!(
-            upgrades,
-            vec![PackageInfo {
-                name: "foo".to_string(),
-                installed_version: Version::new(1, 2, 0),
-                requested_version: VersionReq::STAR
-            }]
-        );
+        assert_eq!(upgrades, vec![InstallRequest::new("foo", VersionReq::STAR)]);
     }
 }

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 
 use crate::app::App;
 use crate::db::{Database, PackageInfo};
-use crate::install::install_with_package_and_requested_version;
+use crate::install::install_package;
 use crate::store::Store;
 use crate::ui::Ui;
 
@@ -41,7 +41,7 @@ pub fn upgrade_cmd(app: &App, ui: &Ui) -> Result<()> {
     }
     for info in to_upgrade {
         ui.info(&format!("Upgrading {}", info.name));
-        install_with_package_and_requested_version(
+        install_package(
             app,
             &ui.nest(),
             false, /* reinstall */

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -32,7 +32,7 @@ fn get_upgrades(ui: &Ui, store: &dyn Store, db: &Database) -> Result<Vec<Package
     Ok(upgrades)
 }
 
-pub fn upgrade(app: &App, ui: &Ui) -> Result<()> {
+pub fn upgrade_cmd(app: &App, ui: &Ui) -> Result<()> {
     ui.info("Checking upgrades");
     let to_upgrade = get_upgrades(&ui.nest(), &*app.store, &app.database)?;
     if to_upgrade.is_empty() {


### PR DESCRIPTION
- Suffix all functions implementing commands with `_cmd`
- chore: rename install_with_package_and_requested_version to install_package
- refactor: rework `install` module
- upgrade: if clyde must be upgraded, upgrade only it
