### PR TITLE
check linux binary is static

### DIFF
--- a/ci/build-app
+++ b/ci/build-app
@@ -30,3 +30,8 @@ else
 fi
 
 $CARGO_CMD build --verbose --release
+
+# On Linux, it's important to ship a static binary. Check this is the case.
+if [ "$OS_NAME" = "linux" ]; then
+    ldd "$EXE_DIR/clyde" | grep -q statically
+fi

--- a/ci/create-archive
+++ b/ci/create-archive
@@ -60,9 +60,6 @@ ARTIFACTS_DIR=$PWD/artifacts
 ARCHIVE_DIR=$APP_NAME-$VERSION
 ARCHIVE_NAME=$APP_NAME-$VERSION-$ARCH-$OS_NAME$ARCHIVE_EXT
 
-# If $CARGO_BUILD_TARGET is defined it must be included in the exe dir
-EXE_DIR=target/${CARGO_BUILD_TARGET:-}/release
-
 rm -rf $ARTIFACTS_DIR
 mkdir -p $ARTIFACTS_DIR/$ARCHIVE_DIR
 

--- a/ci/functions.sh
+++ b/ci/functions.sh
@@ -3,7 +3,7 @@ die() {
     exit 1
 }
 
-# defines ARCH, EXE_EXT, and OS_NAME
+# defines ARCH, EXE_DIR, EXE_EXT, and OS_NAME
 # optionally defines and exports CARGO_BUILD_TARGET
 init_system_vars() {
     ARCH=$(uname -m)
@@ -29,4 +29,7 @@ init_system_vars() {
         die "Unknown OS. uname printed '$out'"
         ;;
     esac
+
+    # If $CARGO_BUILD_TARGET is defined it must be included in the exe dir
+    EXE_DIR=target/${CARGO_BUILD_TARGET:-}/release
 }


### PR DESCRIPTION
- Suffix all functions implementing commands with `_cmd`
- chore: rename install_with_package_and_requested_version to install_package
- refactor: rework `install` module
- upgrade: if clyde must be upgraded, upgrade only it
- Fix functional tests failing on Linux
- ci: check Linux binary is static after building it
