### PR TITLE
Make search more robust

### DIFF
--- a/.changes/unreleased/Fixed-20231217-104755.yaml
+++ b/.changes/unreleased/Fixed-20231217-104755.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: '`clyde search` is now more robust and won''t fail if a package file cannot
+  be parsed.'
+time: 2023-12-17T10:47:55.924348319+01:00

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ pub fn exec(cli: Cli) -> Result<()> {
         }
         Command::Search { query } => {
             let app = App::new(&home)?;
-            search_cmd(&app, &query)
+            search_cmd(&app, &ui, &query)
         }
         Command::List {} => {
             let app = App::new(&home)?;

--- a/src/search.rs
+++ b/src/search.rs
@@ -5,15 +5,19 @@
 use anyhow::Result;
 
 use crate::app::App;
+use crate::ui::Ui;
 
-pub fn search_cmd(app: &App, query: &str) -> Result<()> {
-    let results = app.store.search(query)?;
+pub fn search_cmd(app: &App, ui: &Ui, query: &str) -> Result<()> {
+    let (results, errors) = app.store.search(query)?;
     if results.is_empty() {
         eprintln!("No packages found matching '{query}'");
     } else {
         for result in results {
             println!("{}: {}", result.name, result.description);
         }
+    }
+    for error in errors {
+        ui.warn(&format!("{:#}", error));
     }
     Ok(())
 }

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -119,7 +119,7 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::path::PathBuf;
 
-    use anyhow::anyhow;
+    use anyhow::{anyhow, Error};
     use semver::{Version, VersionReq};
 
     use crate::package::Package;
@@ -151,8 +151,8 @@ mod tests {
                 .ok_or_else(|| anyhow!("No such package: {}", name))?;
             Ok(pkg.clone())
         }
-        fn search(&self, _query: &str) -> Result<Vec<SearchHit>> {
-            Ok(vec![])
+        fn search(&self, _query: &str) -> Result<(Vec<SearchHit>, Vec<Error>)> {
+            Ok((vec![], vec![]))
         }
     }
 


### PR DESCRIPTION
Do not fail if a package file cannot be parsed: print a warning instead.
