### PR TITLE
Simplify download message

### DIFF
--- a/.changes/unreleased/Changed-20230411-092312.yaml
+++ b/.changes/unreleased/Changed-20230411-092312.yaml
@@ -1,0 +1,4 @@
+kind: Changed
+body: 'Download messages have been simplified: they no longer show the number of attempts
+  on the first attempt.'
+time: 2023-04-11T09:23:12.604842811+02:00

--- a/src/download.rs
+++ b/src/download.rs
@@ -125,11 +125,11 @@ fn https_download(ui: &Ui, url_str: &str, dst_path: &Path) -> Result<()> {
 
     for attempt in 1..(DOWNLOAD_ATTEMPTS + 1) {
         if attempt > 1 {
-            ui.warn("Timeout while downloading, retrying");
+            ui.warn(&format!(
+                "Timeout while downloading, retrying (attempt {attempt} / {DOWNLOAD_ATTEMPTS})"
+            ));
         }
-        ui.info(&format!(
-            "Downloading {name} (attempt {attempt} / {DOWNLOAD_ATTEMPTS})"
-        ));
+        ui.info(&format!("Downloading {name}"));
         match https_download_internal(ui, &client, &url, &partial_path) {
             Ok(()) => break,
             Err(err) => match err.downcast_ref::<ReqwestError>() {


### PR DESCRIPTION
Do not show "(attempt 1 / 3)". Only show number of attempts after retrying
once.
