### PR TITLE
Make version_from_tag() more robust

### DIFF
--- a/.changes/unreleased/Changed-20231220-193659.yaml
+++ b/.changes/unreleased/Changed-20231220-193659.yaml
@@ -1,0 +1,4 @@
+kind: Changed
+body: '`clydetools fetch` does not fail anymore to extract version numbers from tags
+  with app name prefixes.'
+time: 2023-12-20T19:36:59.195612609+01:00

--- a/src/bin/clydetools/version_utils.rs
+++ b/src/bin/clydetools/version_utils.rs
@@ -2,33 +2,62 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use regex::Regex;
 use semver::Version;
 
-fn count_chars(txt: &str, wanted: char) -> u32 {
-    let mut count = 0;
-    for ch in txt.chars() {
-        if ch == wanted {
-            count += 1;
-        }
-    }
-    count
+lazy_static! {
+    static ref VERSION_RX: Regex = Regex::new("([0-9]+(\\.[0-9]+)*)$").unwrap();
+}
+
+fn count_chars(txt: &str, wanted: char) -> usize {
+    txt.chars().filter(|&x| x == wanted).count()
 }
 
 /// Extract a version from a tag
 pub fn version_from_tag(tag: &str) -> Result<Version> {
-    let version_str = if tag.starts_with('v') {
-        tag.get(1..).unwrap()
-    } else {
-        tag
+    // Keep only the version suffix
+    let version_str = VERSION_RX
+        .captures(tag)
+        .map(|captures| captures[0].to_string());
+
+    let mut version_str = match version_str {
+        Some(x) => x.to_string(),
+        None => {
+            return Err(anyhow!("Can't find version number in '{}'", tag));
+        }
     };
 
-    let mut version_str = version_str.to_string();
-
+    // Make sure the version has 3 components
     while count_chars(&version_str, '.') < 2 {
         version_str.push_str(".0");
     }
 
     let version = Version::parse(&version_str)?;
     Ok(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_version_from_tag_removes_prefixes() {
+        assert_eq!(version_from_tag("v1.12.0").unwrap(), Version::new(1, 12, 0));
+        assert_eq!(
+            version_from_tag("foo14-1.12.0").unwrap(),
+            Version::new(1, 12, 0)
+        );
+    }
+
+    #[test]
+    fn check_version_from_tag_add_missing_components() {
+        assert_eq!(version_from_tag("1").unwrap(), Version::new(1, 0, 0));
+        assert_eq!(version_from_tag("1.12").unwrap(), Version::new(1, 12, 0));
+    }
+
+    #[test]
+    fn check_version_from_tag_fails() {
+        assert!(version_from_tag("foo").is_err());
+    }
 }


### PR DESCRIPTION
- Do not fail on tags like "gping-v1.16.0".
- Improve implementation of `count_chars()`.
- Add tests.