### PR TITLE
arch os fetcher fixes

### DIFF
--- a/docs/package-file-format.md
+++ b/docs/package-file-format.md
@@ -168,6 +168,8 @@ This fetcher accepts the following entries:
 This fetcher can fetch from any Forgejo-powered code forge. It accepts the following entries:
 
 - `base_url`: required, the base URL of the forge to connect to.
+- `arch`: optional, set a default architecture. Useful when it cannot be deduced from the asset name.
+- `os`: optional, set a default OS. Useful when it cannot be deduced from the asset name.
 
 ### Script fetcher
 

--- a/src/bin/clydetools/forgejo_fetcher.rs
+++ b/src/bin/clydetools/forgejo_fetcher.rs
@@ -82,7 +82,7 @@ impl ForgejoFetcher {
 
 fn get_base_url(package: &Package) -> String {
     match &package.fetcher {
-        FetcherConfig::Forgejo { base_url } => base_url.to_string(),
+        FetcherConfig::Forgejo { base_url, .. } => base_url.to_string(),
         _ => {
             panic!("Forgejo config must include a `base_url` key");
         }
@@ -122,7 +122,17 @@ impl Fetcher for ForgejoFetcher {
             return Ok(UpdateStatus::UpToDate);
         }
 
-        let urls = select_best_urls(ui, &extract_build_urls(&release_json)?, None, None)?;
+        let (default_arch, default_os) = match &package.fetcher {
+            FetcherConfig::Forgejo { arch, os, .. } => (*arch, *os),
+            _ => (None, None),
+        };
+
+        let urls = select_best_urls(
+            ui,
+            &extract_build_urls(&release_json)?,
+            default_arch,
+            default_os,
+        )?;
 
         Ok(UpdateStatus::NeedUpdate {
             version: forgejo_latest_version,

--- a/src/bin/clydetools/gitlab_fetcher.rs
+++ b/src/bin/clydetools/gitlab_fetcher.rs
@@ -55,7 +55,7 @@ impl Fetcher for GitLabFetcher {
         }
 
         let (default_arch, default_os) = match &package.fetcher {
-            FetcherConfig::GitHub { arch, os } => (*arch, *os),
+            FetcherConfig::GitLab { arch, os } => (*arch, *os),
             _ => (None, None),
         };
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -91,6 +91,12 @@ pub enum FetcherConfig {
     #[default]
     Auto,
     Forgejo {
+        #[serde(default)]
+        #[serde(skip_serializing_if = "is_none")]
+        arch: Option<Arch>,
+        #[serde(default)]
+        #[serde(skip_serializing_if = "is_none")]
+        os: Option<Os>,
         base_url: String,
     },
     GitHub {


### PR DESCRIPTION
- **gitlab fetcher: read arch/os from correct enum**
- **forgejo fetcher: add `arch` and `os` optional fields**
