### PR TITLE
Fix crash in `clydetools fetch`

### DIFF
--- a/.changes/unreleased/Fixed-20240409-083819.yaml
+++ b/.changes/unreleased/Fixed-20240409-083819.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: Fix regression in `clydetools fetch` preventing it from updating packages that
+  used the default fetcher
+time: 2024-04-09T08:38:19.042586836+02:00

--- a/src/bin/clydetools/add_assets.rs
+++ b/src/bin/clydetools/add_assets.rs
@@ -231,6 +231,7 @@ impl TryFrom<&FetcherConfig> for BestUrlOptions {
             FetcherConfig::GitLab {
                 arch, os, include, ..
             } => BestUrlOptions::new(*arch, *os, parse_include(include)?),
+            FetcherConfig::Auto {} => BestUrlOptions::new(None, None, None),
             _ => {
                 panic!(
                     "BestUrlOptions::try_from should not be called for {:?}",


### PR DESCRIPTION
BestUrlOptions needs to support the Auto fetcher.
