### PR TITLE
Do not prevent interrupting install with Ctrl-C

### DIFF
--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -11,7 +11,7 @@ use glob_match::glob_match;
 use shell_words;
 
 use crate::app::App;
-use crate::ctrlcutils::CursorRestorer;
+use crate::ctrlcutils::{disable_ctrlc_handler, CursorRestorer};
 use crate::pager::find_pager;
 
 #[derive(Debug, Clone, Copy)]
@@ -114,6 +114,7 @@ fn open_doc_file(doc_file: &Path) -> Result<()> {
 }
 
 pub fn doc_cmd(app: &App, package_name: &str) -> Result<()> {
+    disable_ctrlc_handler();
     let _cursor_restorer = CursorRestorer::new();
     let db = &app.database;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,6 @@ pub fn exec(cli: Cli) -> Result<()> {
 
     let _instance = App::create_single_instance(&home)?;
 
-    ctrlcutils::disable_ctrlc_handler();
-
     let result = match cli.command {
         Command::Setup {
             update_scripts,


### PR DESCRIPTION
Problem: `clyde doc` Ctrl-C hack prevents interrupting other commands, such
as `clyde install`.

Solution: Setup the Ctrl-C hack only in `clyde doc`.
