### PR TITLE
Vendor archiver-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,18 +112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "archiver-rs"
-version = "0.5.1"
-source = "git+https://github.com/agateau/archiver-rs.git?tag=0.5.2#11a2f728dd24344988f50202b5c111936fd0dc6b"
-dependencies = [
- "bzip2",
- "flate2",
- "thiserror 1.0.69",
- "xz2",
- "zip",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,10 +548,10 @@ name = "clyde"
 version = "0.8.0"
 dependencies = [
  "anyhow",
- "archiver-rs",
  "assert_fs",
  "boa_engine",
  "boa_runtime",
+ "bzip2",
  "chrono",
  "clap",
  "clap_complete",
@@ -571,6 +559,7 @@ dependencies = [
  "ctrlc",
  "dialoguer",
  "directories",
+ "flate2",
  "glob-match",
  "goblin",
  "hex",
@@ -589,7 +578,9 @@ dependencies = [
  "single-instance",
  "tar",
  "tempfile",
+ "thiserror 1.0.69",
  "which",
+ "xz2",
  "yare",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ reqwest = { version = "0.13.2", default-features = false, features = ["rustls", 
 indicatif = "0.17.8"
 console = { version = "0.15.8", default-features = false, features = ["ansi-parsing"] }
 regex = "1.7.3"
-archiver-rs = { git = "https://github.com/agateau/archiver-rs.git", tag = "0.5.2", default-features = false, features = ["bzip", "gzip", "xz"] }
 single-instance = "0.3.3"
 boa_engine = { version = "0.21.1", features = ["deser", "trace"] }
 boa_runtime = "0.21.1"
@@ -47,6 +46,12 @@ open = "5.1.2"
 ctrlc = "3.4.4"
 tar = "0.4.45"
 chrono = { version = "0.4.43", features = ["now", "serde"], default-features = false }
+
+# archiver-rs dependencies
+thiserror = "1.0"
+bzip2 = "0.4"
+flate2 = "1.0"
+xz2 = "0.1"
 
 [build-dependencies]
 clap = { version = "4.2.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod test_file_utils;
 pub mod ui;
 pub mod unpacker;
 pub mod vars;
+pub mod vendored;
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/unpacker/single_file_unpacker.rs
+++ b/src/unpacker/single_file_unpacker.rs
@@ -4,8 +4,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::vendored::archiver_rs::{self, Compressed};
 use anyhow::{anyhow, Result};
-use archiver_rs::Compressed;
 
 use crate::file_utils;
 use crate::unpacker::{tar_unpacker::TarUnpacker, Unpacker};

--- a/src/unpacker/tar_unpacker.rs
+++ b/src/unpacker/tar_unpacker.rs
@@ -12,6 +12,8 @@ use tar::Archive;
 use crate::unpacker::unpacker_utils::apply_strip;
 use crate::unpacker::Unpacker;
 
+use crate::vendored::archiver_rs;
+
 pub struct TarUnpacker {
     pub archive_path: PathBuf,
 }

--- a/src/vendored/archiver_rs/Cargo.toml
+++ b/src/vendored/archiver_rs/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "archiver-rs"
+version = "0.5.1"
+authors = ["Chino Chang <chino@joymoe.com>"]
+edition = "2018"
+description = "A library for easy interaction with multiple archive formats"
+documentation = "https://docs.rs/archiver-rs"
+homepage = "https://github.com/JoyMoe/archiver-rs"
+keywords = ["bzip2", "gzip", "tar", "xz", "zip"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/JoyMoe/archiver-rs"
+
+[dependencies]
+thiserror = "1.0"
+
+bzip2 = { version = "0.4", optional = true }
+flate2 = { version = "1.0", optional = true }
+tar = { version = "0.4", optional = true }
+xz2 = { version = "0.1", optional = true }
+
+[dependencies.zip]
+version = "0.6"
+default-features = false
+features = ["deflate", "time"]
+optional = true
+
+[features]
+default = ["all"]
+all = ["bzip", "gzip", "tar", "xz", "zip"]
+bzip = ["bzip2", "zip/bzip2"]
+gzip = ["flate2"]
+xz = ["xz2"]
+zip-all = ["zip", "zip/bzip2"]

--- a/src/vendored/archiver_rs/LICENSE
+++ b/src/vendored/archiver_rs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 - 2020 JoyMoe Interactive Entertainment Limited
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/vendored/archiver_rs/README.md
+++ b/src/vendored/archiver_rs/README.md
@@ -1,0 +1,27 @@
+# archiver-rs
+
+[![Crates.io](https://img.shields.io/crates/v/archiver-rs)](http://crates.io/crates/archiver-rs)
+[![Docs.rs](https://docs.rs/archiver-rs/badge.svg)](https://docs.rs/archiver-rs)
+[![Crates.io](https://img.shields.io/crates/d/archiver-rs)](http://crates.io/crates/archiver-rs)
+[![Crates.io](https://img.shields.io/crates/l/archiver-rs)](https://github.com/JoyMoe/archiver-rs/blob/master/LICENSE)
+
+A library for easy interaction with multiple archive formats
+
+## Usage
+
+```rust
+let mut bz = archiver_rs::Bzip2::open("foo.tar.bz2");
+bz.decompress("foo.tar");
+
+let mut tar = archiver_rs::Tar::open("foo.tar");
+tar.files();
+tar.contains("bar.txt");
+tar.extract("./foo/");
+tar.extract_single("./foo/bar.txt", "bar.txt");
+```
+
+## License
+
+The MIT License
+
+More info see [LICENSE](LICENSE)

--- a/src/vendored/archiver_rs/mod.rs
+++ b/src/vendored/archiver_rs/mod.rs
@@ -1,0 +1,3 @@
+pub mod src;
+
+pub use src::{Bzip2, Compressed, Gzip, Result, Xz};

--- a/src/vendored/archiver_rs/src/bzip2.rs
+++ b/src/vendored/archiver_rs/src/bzip2.rs
@@ -1,0 +1,55 @@
+// #[cfg(feature = "bzip")]
+pub use self::bzip2::Bzip2;
+
+// #[cfg(feature = "bzip")]
+#[allow(clippy::module_inception)]
+mod bzip2 {
+    use std::fs::{create_dir_all, File};
+    use std::io::{copy, Read};
+    use std::path::Path;
+
+    use bzip2::read::BzDecoder;
+
+    use crate::vendored::archiver_rs::{Compressed, Result};
+
+    pub struct Bzip2<R: Read> {
+        archive: BzDecoder<R>,
+    }
+
+    impl Bzip2<File> {
+        pub fn open(path: &Path) -> std::io::Result<Self> {
+            let archive = File::open(path)?;
+
+            Self::new(archive)
+        }
+    }
+
+    impl<R: Read> Bzip2<R> {
+        pub fn new(r: R) -> std::io::Result<Self> {
+            let archive = BzDecoder::new(r);
+
+            Ok(Self { archive })
+        }
+    }
+
+    impl<R: Read> Compressed for Bzip2<R> {
+        fn decompress(&mut self, target: &Path) -> Result<()> {
+            if let Some(p) = target.parent() {
+                if !p.exists() {
+                    create_dir_all(p)?;
+                }
+            }
+
+            let mut output = File::create(target)?;
+            copy(&mut self.archive, &mut output)?;
+
+            Ok(())
+        }
+    }
+
+    impl<R: Read> Read for Bzip2<R> {
+        fn read(&mut self, into: &mut [u8]) -> std::io::Result<usize> {
+            self.archive.read(into)
+        }
+    }
+}

--- a/src/vendored/archiver_rs/src/gzip.rs
+++ b/src/vendored/archiver_rs/src/gzip.rs
@@ -1,0 +1,55 @@
+// #[cfg(feature = "gzip")]
+pub use self::gzip::Gzip;
+
+// #[cfg(feature = "gzip")]
+#[allow(clippy::module_inception)]
+mod gzip {
+    use std::fs::{create_dir_all, File};
+    use std::io::{copy, Read};
+    use std::path::Path;
+
+    use flate2::read::GzDecoder;
+
+    use crate::vendored::archiver_rs::{Compressed, Result};
+
+    pub struct Gzip<R: Read> {
+        archive: GzDecoder<R>,
+    }
+
+    impl Gzip<File> {
+        pub fn open(path: &Path) -> std::io::Result<Self> {
+            let archive = File::open(path)?;
+
+            Self::new(archive)
+        }
+    }
+
+    impl<R: Read> Gzip<R> {
+        pub fn new(r: R) -> std::io::Result<Self> {
+            let archive = GzDecoder::new(r);
+
+            Ok(Self { archive })
+        }
+    }
+
+    impl<R: Read> Compressed for Gzip<R> {
+        fn decompress(&mut self, target: &Path) -> Result<()> {
+            if let Some(p) = target.parent() {
+                if !p.exists() {
+                    create_dir_all(p)?;
+                }
+            }
+
+            let mut output = File::create(target)?;
+            copy(&mut self.archive, &mut output)?;
+
+            Ok(())
+        }
+    }
+
+    impl<R: Read> Read for Gzip<R> {
+        fn read(&mut self, into: &mut [u8]) -> std::io::Result<usize> {
+            self.archive.read(into)
+        }
+    }
+}

--- a/src/vendored/archiver_rs/src/lib.rs
+++ b/src/vendored/archiver_rs/src/lib.rs
@@ -1,0 +1,81 @@
+use std::path::Path;
+
+use thiserror::Error;
+
+#[cfg(feature = "bzip")]
+pub use crate::bzip2::Bzip2;
+
+#[cfg(feature = "gzip")]
+pub use crate::gzip::Gzip;
+
+#[cfg(feature = "tar")]
+pub use crate::tar::Tar;
+
+#[cfg(feature = "xz")]
+pub use crate::xz::Xz;
+
+#[cfg(feature = "zip")]
+pub use crate::zip::Zip;
+
+#[cfg(feature = "bzip")]
+mod bzip2;
+
+#[cfg(feature = "gzip")]
+mod gzip;
+
+#[cfg(feature = "tar")]
+mod tar;
+
+#[cfg(feature = "xz")]
+mod xz;
+
+#[cfg(feature = "zip")]
+mod zip;
+
+#[derive(Error, Debug)]
+pub enum ArchiverError {
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+    #[error("File Not Found")]
+    NotFound,
+}
+
+type Result<T> = std::result::Result<T, ArchiverError>;
+
+pub trait Archive {
+    fn contains(&mut self, file: String) -> Result<bool>;
+
+    fn extract(&mut self, destination: &Path) -> Result<()>;
+
+    fn extract_single(&mut self, target: &Path, file: String) -> Result<()>;
+
+    fn files(&mut self) -> Result<Vec<String>>;
+
+    fn walk(&mut self, f: Box<dyn Fn(String) -> Option<String>>) -> Result<()>;
+}
+
+pub trait Compressed: std::io::Read {
+    fn decompress(&mut self, target: &Path) -> Result<()>;
+}
+
+pub fn open(path: &Path) -> std::io::Result<Box<dyn Archive>> {
+    use std::fs::File;
+    use std::io::{Error, ErrorKind, Read, Seek, SeekFrom};
+
+    let mut file = File::open(&path)?;
+    let mut buffer = [0u8; 2];
+    file.read(&mut buffer)?;
+    file.seek(SeekFrom::Start(0))?;
+
+    match buffer {
+        #[cfg(all(feature = "bzip", feature = "tar"))]
+        [0x42, 0x5A] => Ok(Box::new(Tar::new(Bzip2::new(file)?)?)), // .tar.gz
+        #[cfg(all(feature = "gzip", feature = "tar"))]
+        [0x1F, 0x8B] => Ok(Box::new(Tar::new(Gzip::new(file)?)?)), // .tar.gz
+        #[cfg(all(feature = "xz", feature = "tar"))]
+        [0xFD, 0x37] => Ok(Box::new(Tar::new(Xz::new(file)?)?)), // .tar.xz
+        #[cfg(feature = "zip")]
+        [0x50, 0x4B] => Ok(Box::new(Zip::new(file)?)), // .zip
+        _ => Err(Error::from(ErrorKind::InvalidData))?,
+    }
+}

--- a/src/vendored/archiver_rs/src/mod.rs
+++ b/src/vendored/archiver_rs/src/mod.rs
@@ -1,0 +1,43 @@
+// This file is a copy of lib.rs, simplified to only include the features
+// Clyde needs.
+use std::path::Path;
+
+use thiserror::Error;
+
+pub use bzip2::Bzip2;
+
+pub use gzip::Gzip;
+
+pub use xz::Xz;
+
+mod bzip2;
+
+mod gzip;
+
+mod xz;
+
+#[derive(Error, Debug)]
+pub enum ArchiverError {
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+    #[error("File Not Found")]
+    NotFound,
+}
+
+pub type Result<T> = std::result::Result<T, ArchiverError>;
+
+pub trait Archive {
+    fn contains(&mut self, file: String) -> Result<bool>;
+
+    fn extract(&mut self, destination: &Path) -> Result<()>;
+
+    fn extract_single(&mut self, target: &Path, file: String) -> Result<()>;
+
+    fn files(&mut self) -> Result<Vec<String>>;
+
+    fn walk(&mut self, f: Box<dyn Fn(String) -> Option<String>>) -> Result<()>;
+}
+
+pub trait Compressed: std::io::Read {
+    fn decompress(&mut self, target: &Path) -> Result<()>;
+}

--- a/src/vendored/archiver_rs/src/tar.rs
+++ b/src/vendored/archiver_rs/src/tar.rs
@@ -1,0 +1,102 @@
+#[cfg(feature = "tar")]
+pub use self::tar::Tar;
+
+#[cfg(feature = "tar")]
+mod tar {
+    use std::fs::{create_dir_all, File};
+    use std::io::{copy, Read};
+    use std::path::Path;
+
+    use crate::{Archive, ArchiverError, Result};
+
+    pub struct Tar<R: Read> {
+        archive: tar::Archive<R>,
+    }
+
+    impl Tar<File> {
+        pub fn open(path: &Path) -> std::io::Result<Self> {
+            let archive = File::open(path)?;
+
+            Self::new(archive)
+        }
+    }
+
+    impl<R: Read> Tar<R> {
+        pub fn new(r: R) -> std::io::Result<Self> {
+            let archive = tar::Archive::new(r);
+
+            Ok(Self { archive })
+        }
+    }
+
+    impl<R: Read> Archive for Tar<R> {
+        fn contains(&mut self, file: String) -> Result<bool> {
+            for f in self.archive.entries()? {
+                let f = f?;
+                let name = f.path()?;
+                let name = name.to_str().unwrap_or_else(|| "");
+
+                if name == file {
+                    return Ok(true);
+                }
+            }
+
+            Ok(false)
+        }
+
+        fn extract(&mut self, destination: &Path) -> Result<()> {
+            if !destination.exists() {
+                create_dir_all(destination)?;
+            }
+
+            self.archive.unpack(destination)?;
+
+            Ok(())
+        }
+
+        fn extract_single(&mut self, target: &Path, file: String) -> Result<()> {
+            if let Some(p) = target.parent() {
+                if !p.exists() {
+                    create_dir_all(&p)?;
+                }
+            }
+
+            for f in self.archive.entries()? {
+                let mut f = f?;
+                let name = f.path()?;
+
+                if name.to_str().unwrap_or_else(|| "") == &file {
+                    let mut target = File::create(target)?;
+                    copy(&mut f, &mut target)?;
+
+                    return Ok(());
+                }
+            }
+
+            Err(ArchiverError::NotFound)?
+        }
+
+        fn files(&mut self) -> Result<Vec<String>> {
+            let files = self
+                .archive
+                .entries()?
+                .into_iter()
+                .map(|e| e.unwrap().path().unwrap().to_str().unwrap().into())
+                .collect();
+
+            Ok(files)
+        }
+
+        fn walk(&mut self, f: Box<dyn Fn(String) -> Option<String>>) -> Result<()> {
+            let files = self.files()?;
+
+            for file in files {
+                if let Some(f) = f(file.clone()) {
+                    self.extract_single(Path::new(&f), file.clone())?;
+                }
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/src/vendored/archiver_rs/src/xz.rs
+++ b/src/vendored/archiver_rs/src/xz.rs
@@ -1,0 +1,55 @@
+//#[cfg(feature = "xz")]
+pub use self::xz::Xz;
+
+//#[cfg(feature = "xz")]
+#[allow(clippy::module_inception)]
+mod xz {
+    use std::fs::{create_dir_all, File};
+    use std::io::{copy, Read};
+    use std::path::Path;
+
+    use xz2::read::XzDecoder;
+
+    use crate::vendored::archiver_rs::{Compressed, Result};
+
+    pub struct Xz<R: Read> {
+        archive: XzDecoder<R>,
+    }
+
+    impl Xz<File> {
+        pub fn open(path: &Path) -> std::io::Result<Self> {
+            let archive = File::open(path)?;
+
+            Self::new(archive)
+        }
+    }
+
+    impl<R: Read> Xz<R> {
+        pub fn new(r: R) -> std::io::Result<Self> {
+            let archive = XzDecoder::new(r);
+
+            Ok(Self { archive })
+        }
+    }
+
+    impl<R: Read> Compressed for Xz<R> {
+        fn decompress(&mut self, target: &Path) -> Result<()> {
+            if let Some(p) = target.parent() {
+                if !p.exists() {
+                    create_dir_all(p)?;
+                }
+            }
+
+            let mut output = File::create(target)?;
+            copy(&mut self.archive, &mut output)?;
+
+            Ok(())
+        }
+    }
+
+    impl<R: Read> Read for Xz<R> {
+        fn read(&mut self, into: &mut [u8]) -> std::io::Result<usize> {
+            self.archive.read(into)
+        }
+    }
+}

--- a/src/vendored/archiver_rs/src/zip.rs
+++ b/src/vendored/archiver_rs/src/zip.rs
@@ -1,0 +1,102 @@
+#[cfg(feature = "zip")]
+pub use self::zip::Zip;
+
+#[cfg(feature = "zip")]
+mod zip {
+    use std::fs::{create_dir_all, File};
+    use std::io::{copy, Read, Seek};
+    use std::path::Path;
+
+    use zip::ZipArchive;
+
+    use crate::{Archive, ArchiverError, Result};
+
+    pub struct Zip<R: Read + Seek> {
+        archive: ZipArchive<R>,
+    }
+
+    impl Zip<File> {
+        pub fn open(path: &Path) -> std::io::Result<Self> {
+            let archive = File::open(path)?;
+
+            Self::new(archive)
+        }
+    }
+
+    impl<R: Read + Seek> Zip<R> {
+        pub fn new(r: R) -> std::io::Result<Self> {
+            let archive = ZipArchive::new(r)?;
+
+            Ok(Self { archive })
+        }
+    }
+
+    impl<R: Read + Seek> Archive for Zip<R> {
+        fn contains(&mut self, file: String) -> Result<bool> {
+            let result = match self.archive.by_name(&file) {
+                Ok(_) => true,
+                Err(_) => false,
+            };
+
+            Ok(result)
+        }
+
+        fn extract(&mut self, destination: &Path) -> Result<()> {
+            for i in 0..self.archive.len() {
+                let mut file = self.archive.by_index(i).unwrap();
+                let target = file.mangled_name();
+                let target = destination.join(target);
+
+                if (&*file.name()).ends_with('/') {
+                    create_dir_all(target)?;
+                } else {
+                    if let Some(p) = target.parent() {
+                        if !p.exists() {
+                            create_dir_all(&p)?;
+                        }
+                    }
+                    let mut outfile = File::create(target)?;
+                    copy(&mut file, &mut outfile)?;
+                }
+            }
+
+            Ok(())
+        }
+
+        fn extract_single(&mut self, target: &Path, file: String) -> Result<()> {
+            if let Some(p) = target.parent() {
+                if !p.exists() {
+                    create_dir_all(&p)?;
+                }
+            }
+
+            let mut f = self
+                .archive
+                .by_name(&file)
+                .map_err(|_| ArchiverError::NotFound)?;
+
+            let mut target = File::create(target)?;
+            copy(&mut f, &mut target)?;
+
+            return Ok(());
+        }
+
+        fn files(&mut self) -> Result<Vec<String>> {
+            let files = self.archive.file_names().map(|e| e.into()).collect();
+
+            Ok(files)
+        }
+
+        fn walk(&mut self, f: Box<dyn Fn(String) -> Option<String>>) -> Result<()> {
+            let files = self.files()?;
+
+            for file in files {
+                if let Some(f) = f(file.clone()) {
+                    self.extract_single(Path::new(&f), file.clone())?;
+                }
+            }
+
+            Ok(())
+        }
+    }
+}

--- a/src/vendored/mod.rs
+++ b/src/vendored/mod.rs
@@ -1,0 +1,3 @@
+// Vendor archiver-rs from https://github.com/JoyMoe/archiver-rs until
+// https://github.com/JoyMoe/archiver-rs/pull/6 is merged.
+pub mod archiver_rs;


### PR DESCRIPTION
Problem: latest version of archiver-rs (0.5.1) relies on a version of zip
that itself depends on a version of time that contains a vulnerability.

This [PR][] fixes it, but it's been opened with no answers for 3 years now.

[PR]: https://github.com/JoyMoe/archiver-rs/pull/6

I could turn Clyde into a workspace and have the original crate as a
subcrate, but that requires publishing it separately on crates.io. If I go
this way, I'd rather make it from my own fork of the archiver-rs crate.

Given the size of the code (and Clyde does not even use all of it), vendor
it to avoid the problem.
