### PR TITLE
Make Package use InternalReleaseV2 format

### DIFF
--- a/.changes/unreleased/Changed-20260503-205457.yaml
+++ b/.changes/unreleased/Changed-20260503-205457.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '`clydetools` now writes the `releases` section of packages using the V2 format. This format includes the date the package has been published.'
+time: 2026-05-03T20:54:57.766046604+02:00

--- a/src/package/internal_package.rs
+++ b/src/package/internal_package.rs
@@ -61,14 +61,11 @@ impl From<&Package> for InternalPackage {
                 .iter()
                 .map(|(arch_os, asset)| (arch_os.to_str(), asset.clone()))
                 .collect();
-            /* Uncomment this when we are ready for V2
             let internal_release_v2 = InternalReleaseV2 {
                 published_at: release.published_at,
                 assets,
             };
             releases.insert(version_str, InternalReleaseEnum::V2(internal_release_v2));
-            */
-            releases.insert(version_str, InternalReleaseEnum::V1(assets));
         }
 
         let mut installs = BTreeMap::<String, BTreeMap<String, Install>>::new();

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -356,12 +356,13 @@ mod tests {
             .as_mapping()
             .unwrap();
 
-        // For now we want the V1 format, so there should be only one key: "x86_64-linux"
-        let keys: Vec<String> = release
+        // The release must be using the V2 format, with "assets" and "published_at" keys
+        let mut keys: Vec<String> = release
             .keys()
             .map(|x| x.as_str().unwrap().to_string())
             .collect();
-        assert_eq!(keys, &["x86_64-linux"]);
+        keys.sort();
+        assert_eq!(keys, &["assets", "published_at"]);
     }
 
     #[test]


### PR DESCRIPTION
Now that a version of Clyde that understands the InternalReleaseV2 format
has been published, we can remove the code commented-out in 1470d00 and
start using the V2 format for packages.
