### PR TITLE
Rename published_at to added_at

### DIFF
--- a/docs/package-file-format.md
+++ b/docs/package-file-format.md
@@ -35,16 +35,16 @@ comment: Be careful with XXX
 
 Releases are stored in the `releases` mapping.
 
-Each entry represents a version. the entry value is a mapping that contains a `published_at` entry and an `assets` entry.
+Each entry represents a version. the entry value is a mapping that contains a `added_at` entry and an `assets` entry.
 
-`published_at` is the publication date of the release in ISO-8601. It can be left empty if unknown.
+`added_at` is the date the release has been added to the package file in ISO-8601. It can be left empty if unknown. This is not the date the release was published upstream: it's the date Clyde learned about it.
 
 `assets` is a mapping where entry names are arch-os and entry values are a mapping of two entries: `url` and `sha256`.
 
 ```yaml
 releases:
   "1.2.3":
-    published_at: 2023-04-05T12:34:56Z
+    added_at: 2023-04-05T12:34:56Z
     assets:
       x86_64-linux:
         url: https://example.com/foobar/foobar-1.2.3-x86_64-linux.tar.gz
@@ -63,7 +63,7 @@ releases:
         sha256: 1234567890abcdef
 
   "1.2.1":
-    published_at: 2023-04-02T12:34:56Z
+    added_at: 2023-04-02T12:34:56Z
     assets:
       x86_64-linux:
         url: https://example.com/foobar/foobar-1.2.1-x86_64-linux.tar.gz

--- a/src/bin/clydetools/fetch.rs
+++ b/src/bin/clydetools/fetch.rs
@@ -107,7 +107,7 @@ pub fn fetch_cmd(app: &App, ui: &Ui, paths: &[PathBuf]) -> Result<()> {
             continue;
         }
 
-        let mut release = Release::default().with_published_at(Some(Utc::now()));
+        let mut release = Release::default().with_added_at(Some(Utc::now()));
         for (arch_os, url) in urls {
             add_asset(
                 &ui2,

--- a/src/cmd/show.rs
+++ b/src/cmd/show.rs
@@ -32,14 +32,14 @@ fn show_details(app: &App, package_name: &str) -> Result<()> {
     println!();
     println!("Available versions:");
     for (version, release) in package.releases.iter().rev() {
-        let published_at = match release.published_at {
+        let added_at = match release.added_at {
             Some(x) => format!(" {}", x.to_rfc3339()),
             None => "".into(),
         };
         let mut arch_os_list = Vec::from_iter(release.assets.keys().map(|x| format!("{x}")));
         arch_os_list.sort();
         let arch_os_str = arch_os_list.join(", ");
-        println!("- {version} ({arch_os_str}){published_at}");
+        println!("- {version} ({arch_os_str}){added_at}");
     }
     Ok(())
 }
@@ -68,7 +68,7 @@ fn show_as_json(app: &App, package_name: &str, list: bool) -> Result<()> {
             json!({
                 "version": version.to_string(),
                 "arch_os": arch_os_list,
-                "published_at": release.published_at,
+                "added_at": release.added_at,
             })
         })
         .collect();

--- a/src/package/internal_package.rs
+++ b/src/package/internal_package.rs
@@ -15,7 +15,7 @@ use crate::package::{Asset, FetcherConfig, Install, Package, Release};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct InternalReleaseV2 {
-    published_at: Option<DateTime<Utc>>,
+    added_at: Option<DateTime<Utc>>,
     // Key is arch-os
     assets: BTreeMap<String, Asset>,
 }
@@ -62,7 +62,7 @@ impl From<&Package> for InternalPackage {
                 .map(|(arch_os, asset)| (arch_os.to_str(), asset.clone()))
                 .collect();
             let internal_release_v2 = InternalReleaseV2 {
-                published_at: release.published_at,
+                added_at: release.added_at,
                 assets,
             };
             releases.insert(version_str, InternalReleaseEnum::V2(internal_release_v2));
@@ -108,7 +108,7 @@ impl InternalPackage {
                             })
                             .collect();
                         Release::default()
-                            .with_published_at(internal_release.published_at)
+                            .with_added_at(internal_release.added_at)
                             .with_assets(assets)
                     }
                     InternalReleaseEnum::V1(internal_release) => {

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -32,7 +32,7 @@ pub type ReleaseAssets = HashMap<ArchOs, Asset>;
 
 #[derive(Debug, Clone, Default)]
 pub struct Release {
-    pub published_at: Option<DateTime<Utc>>,
+    pub added_at: Option<DateTime<Utc>>,
     pub assets: ReleaseAssets,
 }
 
@@ -42,8 +42,8 @@ impl Release {
         self
     }
 
-    pub fn with_published_at(mut self, published_at: Option<DateTime<Utc>>) -> Self {
-        self.published_at = published_at;
+    pub fn with_added_at(mut self, added_at: Option<DateTime<Utc>>) -> Self {
+        self.added_at = added_at;
         self
     }
 }
@@ -205,7 +205,7 @@ mod tests {
           url: https://example.com/foo-1.2.0
           sha256: '1234'
       1.3.0:
-        published_at: '2024-01-02T12:34:56Z'
+        added_at: '2024-01-02T12:34:56Z'
         assets:
           any:
             url: https://example.com/foo-1.3.0
@@ -287,7 +287,7 @@ mod tests {
             .releases
             .get(&Version::from_str("1.2.0").unwrap())
             .unwrap();
-        assert!(release_120.published_at.is_none());
+        assert!(release_120.added_at.is_none());
         let asset_120 = release_120.assets.get(&ArchOs::any()).unwrap();
         assert_eq!(asset_120.sha256, "1234");
 
@@ -297,7 +297,7 @@ mod tests {
             .get(&Version::from_str("1.3.0").unwrap())
             .unwrap();
         assert_eq!(
-            release_130.published_at,
+            release_130.added_at,
             Some(
                 DateTime::parse_from_rfc3339("2024-01-02T12:34:56Z")
                     .unwrap()
@@ -356,13 +356,13 @@ mod tests {
             .as_mapping()
             .unwrap();
 
-        // The release must be using the V2 format, with "assets" and "published_at" keys
+        // The release must be using the V2 format, with "assets" and "added_at" keys
         let mut keys: Vec<String> = release
             .keys()
             .map(|x| x.as_str().unwrap().to_string())
             .collect();
         keys.sort();
-        assert_eq!(keys, &["assets", "published_at"]);
+        assert_eq!(keys, &["added_at", "assets"]);
     }
 
     #[test]


### PR DESCRIPTION
"added_at" is less ambiguous than "published_at" to express the fact that
this is the time the release was added to Clyde, not the time the release
was published upstream.
