### PR TITLE
Implement cooldown

### DIFF
--- a/.changes/unreleased/Added-20260514-174435.yaml
+++ b/.changes/unreleased/Added-20260514-174435.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Clyde now imposes a cooldown of 7 days: it refuses to install a package that has been added to the Clyde Store less than 7 days ago.'
+time: 2026-05-14T17:44:35.559211516+02:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "shell-words",
  "single-instance",
  "tar",
+ "temp_env_vars",
  "tempfile",
  "thiserror 1.0.69",
  "which",
@@ -2855,6 +2856,25 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "temp_env_vars"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d44eec4b6fb0b9a8853b7180c2124b03f062f971fe0aeb47838a7acb07b17b8"
+dependencies = [
+ "temp_env_vars_macro",
+]
+
+[[package]]
+name = "temp_env_vars_macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e3381d9dcf425c55c450a365adb18de503f2a946f13eb05eb0402b53482484"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,5 @@ clap_complete = { version = "4.2.0" }
 
 [dev-dependencies]
 assert_fs = "1.0.12"
+temp_env_vars = "0.2.1"
 yare = "3.0.0"

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ Shows the list of documentation files provided by the `foobar` package. Let you 
 
 Yes, but it still requires you to be careful.
 
-It is more secure in that Clyde checks the integrity of all downloaded archives (The Clyde store contains the sha256 checksum of all known archives), making it more complicated for an attacker to trick you into installing a corrupted archive.
+It is more secure because Clyde checks the integrity of all downloaded archives (The Clyde store contains the sha256 checksum of all known archives), making it more complicated for an attacker to trick you into installing a corrupted archive. If an attacker takes over the GitHub account of an app developer and replaces some release artifacts with others, Clyde will refuse to install them.
 
-This means if an attacker takes over the GitHub account of an app developer and replaces some release artifacts with others, Clyde will refuse to install them. It does not protect however from the case where the attacker releases a new version of the application. To protect against this you need to pin the version numbers.
+It does not provide absolute protection against the case where the attacker releases a new version of the package but it mitigates the effectiveness of such attack by imposing a cooldown of 7 days: Clyde won't install a release that has been added less than 7 days ago. The hope is that if a rogue package is published it will be detected and taken down before the cooldown expires. To truely protect against this you need to pin the version numbers. The duration of the cooldown can be changed using the `$CLYDE_COOLDOWN_DAYS` environment variable.
 
 Clyde does not sandbox the applications.
 

--- a/functests/test_install.py
+++ b/functests/test_install.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from datetime import datetime
 import json
 
 from pathlib import Path
@@ -85,3 +86,31 @@ def test_install_cleans_after_itself_in_case_of_failure(clyde_home):
         # AND the existing file has been left untouched
         assert existing_path.read_text() == "foo"
         existing_path.unlink()
+
+
+def set_cooldown_to(monkeypatch, cooldown_date: datetime):
+    now = datetime.now()
+    days = (now - cooldown_date).days
+    monkeypatch.setenv("CLYDE_COOLDOWN_DAYS", str(days))
+
+
+def test_install_applies_cooldown(monkeypatch, clyde_home):
+    # GIVEN a Clyde home
+    # AND a cooldown that prevents installation of zellij 0.44.3 (added on 2006-05-13)
+    set_cooldown_to(monkeypatch, datetime(2026, 5, 10))
+    # WHEN running `clyde install zellij`
+    run_clyde("install", "zellij")
+
+    # THEN `zellij --version` says 0.44.2
+    result = run_in_clyde_home("zellij --version")
+    assert "zellij 0.44.2" in result.stdout
+
+    # WHEN cooldown is set to after the 0.44.3 release
+    set_cooldown_to(monkeypatch, datetime(2026, 5, 15))
+
+    # AND we run `clyde install zellij`
+    run_clyde("install", "zellij")
+
+    # THEN it installs version 0.44.3
+    result = run_in_clyde_home("zellij --version")
+    assert "zellij 0.44.3" in result.stdout

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,6 +17,8 @@ use crate::db::Database;
 use crate::file_cache::FileCache;
 use crate::store::{GitStore, Store};
 
+const DEFAULT_COOLDOWN_DAYS: usize = 7;
+
 pub struct App {
     pub download_cache: FileCache,
     pub home: PathBuf,
@@ -33,6 +35,16 @@ fn create_single_instance_name(home: &Path) -> String {
     let mut hasher = Sha256::default();
     hasher.update(home.to_string_lossy().as_bytes());
     hex::encode(hasher.finalize_reset())
+}
+
+fn read_cooldown_days() -> usize {
+    let Some(value) = env::var_os("CLYDE_COOLDOWN_DAYS") else {
+        return DEFAULT_COOLDOWN_DAYS;
+    };
+    let Some(value) = value.to_str() else {
+        return DEFAULT_COOLDOWN_DAYS;
+    };
+    str::parse(value).unwrap_or(DEFAULT_COOLDOWN_DAYS)
 }
 
 impl App {
@@ -71,7 +83,8 @@ impl App {
             ));
         }
         let store_dir = home.join("store");
-        let store = GitStore::new(&store_dir);
+        let mut store = GitStore::new(&store_dir);
+        store.set_cooldown_days(read_cooldown_days());
 
         let db_path = home.join("clyde.sqlite");
         let database = Database::new_from_path(&db_path)?;
@@ -88,5 +101,29 @@ impl App {
             store: Box::new(store),
             database,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use temp_env_vars::temp_env_vars;
+
+    use super::*;
+
+    #[test]
+    #[temp_env_vars]
+    fn app_use_default_cooldown_days() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        let app = App::new(&dir).unwrap();
+        assert_eq!(app.store.cooldown_days(), DEFAULT_COOLDOWN_DAYS);
+    }
+
+    #[test]
+    #[temp_env_vars]
+    fn app_env_override_cooldown_days() {
+        env::set_var("CLYDE_COOLDOWN_DAYS", "2");
+        let dir = assert_fs::TempDir::new().unwrap();
+        let app = App::new(&dir).unwrap();
+        assert_eq!(app.store.cooldown_days(), 2);
     }
 }

--- a/src/bin/clydetools/check_package.rs
+++ b/src/bin/clydetools/check_package.rs
@@ -179,7 +179,8 @@ fn check_can_install(package: &Package, package_path: &Path, version: &Version) 
         Command::new("clyde")
             .arg("install")
             .arg(format!("{package_str}@={version}"))
-            .env("CLYDE_HOME", home_dir.as_os_str()),
+            .env("CLYDE_HOME", home_dir.as_os_str())
+            .env("CLYDE_COOLDOWN_DAYS", "0"),
     )
     .map_err(|_| anyhow!(report.join("\n")))?;
 

--- a/src/cmd/upgrade.rs
+++ b/src/cmd/upgrade.rs
@@ -138,6 +138,10 @@ mod tests {
     }
 
     impl Store for FakeStore {
+        fn cooldown_days(&self) -> usize {
+            0
+        }
+        fn set_cooldown_days(&mut self, _cooldown_days: usize) {}
         fn setup(&self, _url: &str) -> Result<()> {
             Ok(())
         }

--- a/src/package/mod.rs
+++ b/src/package/mod.rs
@@ -10,7 +10,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 
@@ -186,10 +186,24 @@ impl Package {
         let installs_for_arch_os = entry.1;
         installs_for_arch_os.get(arch_os)
     }
+
+    /// Return a copy of self without releases that were added less than `cooldown_days` ago
+    pub fn enforce_cooldown_days(&self, cooldown_days: usize) -> Self {
+        let mut package = self.clone();
+
+        let max_added_at = Utc::now() - TimeDelta::days(cooldown_days as i64);
+        package.releases.retain(|&_, r| match r.added_at {
+            None => true,
+            Some(added_at) => added_at <= max_added_at,
+        });
+        package
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use chrono::TimeDelta;
+
     use super::*;
     use std::{fs, str::FromStr};
 
@@ -495,5 +509,44 @@ mod tests {
             .get_install(&Version::new(1, 0, 0), &ArchOs::any())
             .unwrap();
         assert_eq!(install.strip, 0);
+    }
+
+    #[test]
+    fn enforce_cooldown_days_remove_too_recent_release() {
+        // GIVEN a package with release 2.0 from 2 day ago
+        // AND release 1.0 from 4 days ago
+        let now = Utc::now();
+        let v1_added_at = now - TimeDelta::days(4);
+        let v2_added_at = now - TimeDelta::days(2);
+        let package = Package::from_yaml_str(&format!(
+            "
+            name: foo
+            description: The foo package
+            homepage:
+            releases:
+              1.0.0:
+                added_at: {}
+                assets:
+                  any:
+                    url: https://example.com/foo
+                    sha256: '1234'
+              2.0.0:
+                added_at: {}
+                assets:
+                  any:
+                    url: https://example.com/foo
+                    sha256: '1234'
+            installs: {{}}
+            ",
+            v1_added_at, v2_added_at
+        ))
+        .unwrap();
+
+        // WHEN enforce_cooldown_days(3) is called
+        let package = package.enforce_cooldown_days(3);
+
+        // THEN only release 1.0 is kept
+        let versions: Vec<Version> = package.releases.keys().cloned().collect();
+        assert_eq!(versions, &[Version::new(1, 0, 0)]);
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -22,6 +22,8 @@ pub struct SearchHit {
 }
 
 pub trait Store {
+    fn cooldown_days(&self) -> usize;
+    fn set_cooldown_days(&mut self, cooldown_days: usize);
     fn setup(&self, url: &str) -> Result<()>;
     fn update(&self) -> Result<()>;
     fn get_package(&self, name: &str) -> Result<Package>;
@@ -30,6 +32,7 @@ pub trait Store {
 
 pub struct GitStore {
     dir: PathBuf,
+    cooldown_days: usize,
 }
 
 impl SearchHit {
@@ -45,6 +48,7 @@ impl GitStore {
     pub fn new(dir: &Path) -> GitStore {
         GitStore {
             dir: dir.to_path_buf(),
+            cooldown_days: 0,
         }
     }
 
@@ -105,6 +109,14 @@ fn get_package_path(path: &Path) -> Option<PathBuf> {
 }
 
 impl Store for GitStore {
+    fn cooldown_days(&self) -> usize {
+        self.cooldown_days
+    }
+
+    fn set_cooldown_days(&mut self, cooldown_days: usize) {
+        self.cooldown_days = cooldown_days;
+    }
+
     fn setup(&self, url: &str) -> Result<()> {
         let mut cmd = Command::new("git");
         cmd.args(["clone", "--depth", "1", url]);
@@ -142,7 +154,8 @@ impl Store for GitStore {
         let path = self
             .find_package_path(name)
             .ok_or_else(|| anyhow!("No such package: {}", name))?;
-        Package::from_file(&path)
+        let package = Package::from_file(&path)?;
+        Ok(package.enforce_cooldown_days(self.cooldown_days))
     }
 
     fn search(&self, query_: &str) -> Result<(Vec<SearchHit>, Vec<Error>)> {
@@ -217,6 +230,8 @@ mod tests {
 
     use std::vec::Vec;
 
+    use chrono::{TimeDelta, Utc};
+    use semver::Version;
     use yare::parameterized;
 
     use crate::test_file_utils::{create_tree, CwdSaver};
@@ -226,12 +241,10 @@ mod tests {
     }
 
     fn create_package_file_with_desc(dir: &Path, name: &str, desc: &str) {
-        let package_dir = dir.join(name);
-        fs::create_dir(&package_dir).unwrap();
-        let path = package_dir.join(INDEX_NAME);
-        fs::write(
-            path,
-            format!(
+        create_package_file_with_content(
+            dir,
+            name,
+            &format!(
                 "
         name: {name}
         description: {desc}
@@ -242,8 +255,14 @@ mod tests {
                 name = name,
                 desc = desc
             ),
-        )
-        .unwrap();
+        );
+    }
+
+    fn create_package_file_with_content(dir: &Path, name: &str, content: &str) {
+        let package_dir = dir.join(name);
+        fs::create_dir(&package_dir).unwrap();
+        let path = package_dir.join(INDEX_NAME);
+        fs::write(path, content).unwrap();
     }
 
     fn create_old_package_file_with_desc(dir: &Path, name: &str, desc: &str) {
@@ -361,5 +380,54 @@ mod tests {
         let error = &errors[0];
         print!("{}", error.to_string());
         assert!(error.to_string().contains("bar"));
+    }
+
+    #[test]
+    fn get_package_enforces_cooldown() {
+        let dir = assert_fs::TempDir::new().unwrap();
+        // GIVEN a store with a cooldown of 3 days
+        let mut store = GitStore::new(&dir);
+        store.set_cooldown_days(3);
+
+        // AND the store has a package foo with 2 releases:
+        // - 1.0 that is 4 days old
+        // - 2.0 that is 2 day old
+        let now = Utc::now();
+        let v1_added_at = now - TimeDelta::days(4);
+        let v2_added_at = now - TimeDelta::days(2);
+        create_package_file_with_content(
+            &dir,
+            "foo",
+            &format!(
+                "
+                name: foo
+                description: The foo package
+                homepage:
+                releases:
+                  1.0.0:
+                    added_at: {}
+                    assets:
+                      any:
+                        url: https://example.com/foo
+                        sha256: '1234'
+                  2.0.0:
+                    added_at: {}
+                    assets:
+                      any:
+                        url: https://example.com/foo
+                        sha256: '1234'
+                installs: {{}}
+            ",
+                v1_added_at, v2_added_at
+            ),
+        );
+
+        // WHEN searching for foo
+        // THEN it returns a Package instance
+        let package = store.get_package("foo").unwrap();
+
+        // AND this instance only contains the 1.0 release
+        let versions: Vec<Version> = package.releases.keys().cloned().collect();
+        assert_eq!(versions, &[Version::new(1, 0, 0)]);
     }
 }


### PR DESCRIPTION
To mitigate supply-chain attacks, Clyde won't install releases that have
been added to its index less than 7 days ago.

This value can be overridden by defining the CLYDE_COOLDOWN_DAYS
environment variable.
